### PR TITLE
Remove Checklist section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,6 @@
 
 Brief description of what this PR does, and why it is needed.
 
-### Checklist
-
-- [ ] PR has a descriptive enough title to be useful in changelogs
-
 ### Demo
 
 Optional. Screenshots, `curl` examples, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@ Optional. Screenshots, `curl` examples, etc.
 
 Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
 
-
 ## Testing Instructions
 
  * How to test this PR
@@ -19,4 +18,4 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
  * Include any setup required, such as bundling scripts, restarting services, etc.
  * Include test case, and expected output
 
-Closes #XXX
+Connects #XXX


### PR DESCRIPTION
## Overview

Currently, the only `Checklist` item in the PR template is `PR has a descriptive enough title to be useful in changelogs`, which doesn't apply in our case since we're not using an automated changelog generator.

Remove the `Checklist` section from the PR template to avoid maintaining a step that we always skip.

### Notes

We can always bring the `Checklist` section back if we decide we need new items.

## Testing Instructions

 * View the rendered markdown and confirm that it's formatted properly: https://github.com/datamade/just-spaces/blob/jfc/remove-pr-template-checklist/.github/pull_request_template.md
