### PR TITLE
Add publish view

### DIFF
--- a/surveys/templates/base.html
+++ b/surveys/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!doctype html>
 <html lang="en">

--- a/surveys/templates/survey_list.html
+++ b/surveys/templates/survey_list.html
@@ -18,6 +18,7 @@
         <th scope="col">Edit</th>
         <th scope="col">Run</th>
         <th scope="col">Delete</th>
+        <th scope="col">Publish</th>
       </tr>
     </thead>
     <tbody>
@@ -29,6 +30,11 @@
           <td><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>
           <td><a href="{% url 'fobi.view_form_entry' survey.slug %}"><i class="fas fa-clipboard-list icon run"></i></a></td>
           <td><a href="{% url 'fobi.delete_form_entry' survey.id %}"><i class="fas fa-times icon delete"></i></a></td>
+          {% if not survey.published %}
+          <td><a href="{% url 'surveys-publish' survey.id %}"><i class="far fa-newspaper icon delete"></i></a></td>
+          {% else %}
+          <td></td>
+          {% endif %}
         </tr>
       {% endfor %}
     </tbody>

--- a/surveys/templates/survey_publish.html
+++ b/surveys/templates/survey_publish.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block content %}
+  <h2>Publish survey</h2>
+  <form method="POST" class="post-form">{% csrf_token %}
+     <div>Are you sure you want to publish <b>{{survey.name}}</b>?</div>
+     <div>Surveys must be published before they can be run, but cannot be edited
+       once they've been published.</div>
+     <button type="submit" class="save btn btn-default">Publish</button>
+  </form>
+{% endblock %}

--- a/surveys/templates/survey_publish.html
+++ b/surveys/templates/survey_publish.html
@@ -4,9 +4,9 @@
 {% block content %}
   <h2>Publish survey</h2>
   <form method="POST" class="post-form">{% csrf_token %}
-     <div>Are you sure you want to publish <b>{{survey.name}}</b>?</div>
-     <div>Surveys must be published before they can be run, but cannot be edited
-       once they've been published.</div>
+     <p>Are you sure you want to publish <b>{{survey.name}}</b>?</p>
+     <p>Surveys must be published before they can be run, but cannot be edited
+       once they've been published.</p>
      <button type="submit" class="save btn btn-default">Publish</button>
   </form>
 {% endblock %}

--- a/surveys/urls.py
+++ b/surveys/urls.py
@@ -9,8 +9,8 @@ from django.conf.urls import url, include
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.decorators import login_required
 from surveys.views import AgencyCreate, LocationCreate, StudyCreate, \
-                                SurveyCreate, SurveyList, Signup, \
-                                SurveySubmittedList, SurveySubmittedDetail
+                                SurveyCreate, SurveyPublish, SurveyList, \
+                                Signup, SurveySubmittedList, SurveySubmittedDetail
 import fobi.views
 
 urlpatterns = [
@@ -90,6 +90,11 @@ urlpatterns = [
     url(_(r'^surveys/delete/(?P<form_entry_id>\d+)/$'),
         view=fobi.views.delete_form_entry,
         name='fobi.delete_form_entry'),
+
+    # Publish survey
+    url(_(r'^surveys/publish/(?P<form_entry_id>\d+)/$'),
+        view=SurveyPublish.as_view(),
+        name='surveys-publish'),
 
     # Survey detail
     url(_(r'^surveys/view/(?P<form_entry_slug>[\w_\-]+)/$'),

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -1,4 +1,4 @@
-from django.views.generic import TemplateView, ListView
+from django.views.generic import TemplateView, ListView, View
 from django.views.generic.edit import CreateView, FormView
 from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect
@@ -51,6 +51,23 @@ class SurveyCreate(CreateView):
                                )
 
         return HttpResponseRedirect(self.get_success_url())
+
+
+class SurveyPublish(TemplateView):
+    template_name = "survey_publish.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['survey'] = SurveyFormEntry.objects.get(id=context['form_entry_id'])
+
+        return context
+
+    def post(self, request, **kwargs):
+        context = self.get_context_data(**kwargs)
+        context['survey'].published = True
+        context['survey'].save()
+
+        return redirect('survey-list')
 
 
 class SurveyList(ListView):

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -67,7 +67,7 @@ class SurveyPublish(TemplateView):
         context['survey'].published = True
         context['survey'].save()
 
-        return redirect('survey-list')
+        return redirect('surveys-list')
 
 
 class SurveyList(ListView):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def survey_form_entry(db, user, location, study):
         'id': 1,
         'user': user,
         'name': 'Sample Form Entry',
-        'published': True,
+        'published': False,
         'location': location,
         'study': study,
         'type': 'observational',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import datetime
 from django.core.management import call_command
+from django.utils.timezone import get_current_timezone
 
 from fobi.models import FormElementEntry
 from users.models import JustSpacesUser
@@ -135,7 +136,7 @@ def form_element_help_text(db, survey_form_entry):
 @pytest.mark.django_db
 def survey(db, location, study):
     survey = Survey.objects.create(
-        time_stop=datetime.now(tz=None),
+        time_stop=datetime.now(tz=get_current_timezone()),
         location=location,
         study=study,
         form_id=1,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,5 +16,5 @@ def test_survey_form_entry(client, user, survey_form_entry):
     saved_survey_form_entry = SurveyFormEntry.objects.first()
 
     assert saved_survey_form_entry.name == 'Sample Form Entry'
-    assert saved_survey_form_entry.published
+    assert not saved_survey_form_entry.published
     assert saved_survey_form_entry.type == 'observational'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,20 @@ from django.urls import reverse
 
 
 @pytest.mark.django_db
+def test_survey_publish(client, survey_form_entry):
+    assert not survey_form_entry.published
+
+    url = reverse('surveys-publish', kwargs={'form_entry_id': survey_form_entry.id})
+
+    get_response = client.get(url)
+    assert get_response.status_code == 200
+
+    post_response = client.post(url)
+    assert post_response.status_code == 302
+    # assert survey_form_entry.published
+
+
+@pytest.mark.django_db
 def test_survey_submitted_list(client, user, survey, survey_form_entry):
     client.force_login(user)
     url = reverse('surveys-submitted-list')
@@ -18,10 +32,8 @@ def test_survey_submitted_list(client, user, survey, survey_form_entry):
 @pytest.mark.django_db
 def test_survey_submitted_detail(client, user, survey_form_entry, survey, survey_row, survey_component):
     client.force_login(user)
-    url = reverse('surveys-submitted-detail', kwargs={'form_entry_id': survey_form_entry.id})
-    print("hello")
-    print(url)
 
+    url = reverse('surveys-submitted-detail', kwargs={'form_entry_id': survey_form_entry.id})
     response = client.get(url)
 
     surveys_submitted = response.context['surveys_submitted']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,11 +9,14 @@ def test_survey_publish(client, survey_form_entry):
     url = reverse('surveys-publish', kwargs={'form_entry_id': survey_form_entry.id})
 
     get_response = client.get(url)
+
     assert get_response.status_code == 200
 
     post_response = client.post(url)
+    survey_form_entry.refresh_from_db()
+
     assert post_response.status_code == 302
-    # assert survey_form_entry.published
+    assert survey_form_entry.published
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

This PR adds a view, template, and url for publishing surveys. Once this is approved I can move forward with #32 and improving the `survey-list` template to better reflect the difference between published and unpublished surveys.

It'll be nice to have tests on this, but I think that makes more sense to implement once I'm also working on #32 

## Testing Instructions

 * If you don't already have it, create the database: `pg_restore -C -j4 --no-owner just-spaces.dump | psql`
* Migrate: `python manage.py migrate`
* Login as testuser (password in the DataMade LastPass under "Just Spaces Staging")
* Create a new survey
* Go to the survey list view
* Do you see a button under the "Published" column?
* Click it. Does it prompt you on whether or not you want to publish the survey?
* Submit that. Does the survey no longer have a "Publish" button?

Connects #54 
