### PR TITLE
Published state

### DIFF
--- a/justspaces/settings.py
+++ b/justspaces/settings.py
@@ -144,7 +144,7 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
-LOGIN_REDIRECT_URL = 'surveys-list'
+LOGIN_REDIRECT_URL = 'surveys-list-run'
 
 FOBI_DEFAULT_THEME = 'foundation5'
 FOBI_THEME_FOOTER_TEXT = gettext.gettext('')

--- a/surveys/templates/partials/sidebar.html
+++ b/surveys/templates/partials/sidebar.html
@@ -26,13 +26,13 @@
                 </ul>
             </li>
             <li>
-                <a href="{% url 'surveys-list' %}">
+                <a href="{% url 'surveys-list' %}?published=f">
                     <i class="fas fa-pencil-alt icon edit"></i>
                     Edit survey
                 </a>
             </li>
             <li>
-                <a href="{% url 'surveys-list' %}">
+                <a href="{% url 'surveys-list' %}?published=t">
                     <i class="fas fa-clipboard-list icon run"></i>
                     Run survey
                 </a>

--- a/surveys/templates/partials/sidebar.html
+++ b/surveys/templates/partials/sidebar.html
@@ -26,13 +26,13 @@
                 </ul>
             </li>
             <li>
-                <a href="{% url 'surveys-list' %}?published=f">
+                <a href="{% url 'surveys-list-edit' %}">
                     <i class="fas fa-pencil-alt icon edit"></i>
                     Edit survey
                 </a>
             </li>
             <li>
-                <a href="{% url 'surveys-list' %}?published=t">
+                <a href="{% url 'surveys-list-run' %}">
                     <i class="fas fa-clipboard-list icon run"></i>
                     Run survey
                 </a>

--- a/surveys/templates/survey_list.html
+++ b/surveys/templates/survey_list.html
@@ -5,8 +5,11 @@
 
 <div class="card">
   <div class="card-body">
-
+    {% if published == 't' %}
     <h2 class="card-title">Run Survey</h2>
+    {% else %}
+    <h2 class="card-title">Edit Survey</h2>
+    {% endif %}
     <br />
 
     <table class="table table-hover table-striped card-text">
@@ -15,10 +18,12 @@
         <th scope="col">Survey Name</th>
         <th scope="col">Created</th>
         <th scope="col">Updated</th>
-        <th scope="col">Edit</th>
+        {% if published == 't' %}
         <th scope="col">Run</th>
-        <th scope="col">Delete</th>
+        {% else %}
+        <th scope="col">Edit</th>
         <th scope="col">Publish</th>
+        {% endif %}
       </tr>
     </thead>
     <tbody>
@@ -27,13 +32,11 @@
           <td><b>{{survey.name}}</b></td>
           <td>{{survey.created}}</td>
           <td>{{survey.updated}}</td>
-          <td><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>
+          {% if published == 't' %}
           <td><a href="{% url 'fobi.view_form_entry' survey.slug %}"><i class="fas fa-clipboard-list icon run"></i></a></td>
-          <td><a href="{% url 'fobi.delete_form_entry' survey.id %}"><i class="fas fa-times icon delete"></i></a></td>
-          {% if not survey.published %}
-          <td><a href="{% url 'surveys-publish' survey.id %}"><i class="far fa-newspaper icon delete"></i></a></td>
           {% else %}
-          <td></td>
+          <td><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>
+          <td><a href="{% url 'surveys-publish' survey.id %}"><i class="far fa-newspaper icon delete"></i></a></td>
           {% endif %}
         </tr>
       {% endfor %}

--- a/surveys/templates/survey_list.html
+++ b/surveys/templates/survey_list.html
@@ -5,7 +5,7 @@
 
 <div class="card">
   <div class="card-body">
-    {% if published == 't' %}
+    {% if published %}
     <h2 class="card-title">Run Survey</h2>
     {% else %}
     <h2 class="card-title">Edit Survey</h2>
@@ -18,7 +18,7 @@
         <th scope="col">Survey Name</th>
         <th scope="col">Created</th>
         <th scope="col">Updated</th>
-        {% if published == 't' %}
+        {% if published %}
         <th scope="col">Run</th>
         {% else %}
         <th scope="col">Edit</th>
@@ -32,7 +32,7 @@
           <td><b>{{survey.name}}</b></td>
           <td>{{survey.created}}</td>
           <td>{{survey.updated}}</td>
-          {% if published == 't' %}
+          {% if published %}
           <td><a href="{% url 'fobi.view_form_entry' survey.slug %}"><i class="fas fa-clipboard-list icon run"></i></a></td>
           {% else %}
           <td><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>

--- a/surveys/urls.py
+++ b/surveys/urls.py
@@ -9,14 +9,15 @@ from django.conf.urls import url, include
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.decorators import login_required
 from surveys.views import AgencyCreate, LocationCreate, StudyCreate, \
-                                SurveyCreate, SurveyPublish, SurveyList, \
-                                Signup, SurveySubmittedList, SurveySubmittedDetail
+                                SurveyCreate, SurveyPublish, SurveyListEdit, \
+                                SurveyListRun, Signup, SurveySubmittedList, \
+                                SurveySubmittedDetail
 import fobi.views
 
 urlpatterns = [
     # placeholder view for a public-facing landing page
     url(r'^$',
-        login_required(SurveyList.as_view()),
+        login_required(SurveyListRun.as_view()),
         name='home'),
 
     url(r'^accounts/',
@@ -25,7 +26,6 @@ urlpatterns = [
     url(r'^accounts/signup$',
         Signup.as_view(),
         name='signup'),
-
 
     url(r'agencies/create/$',
         login_required(AgencyCreate.as_view()),
@@ -39,10 +39,15 @@ urlpatterns = [
         login_required(StudyCreate.as_view()),
         name='studies-create'),
 
-    # Survey list
-    url(r'surveys/$',
-        login_required(SurveyList.as_view()),
-        name='surveys-list'),
+    # Survey list edit
+    url(r'surveys/edit/$',
+        login_required(SurveyListEdit.as_view()),
+        name='surveys-list-edit'),
+
+    # Survey list run
+    url(r'surveys/run/$',
+        login_required(SurveyListRun.as_view()),
+        name='surveys-list-run'),
 
     # Create new survey
     url(r'surveys/create/$',

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -1,4 +1,4 @@
-from django.views.generic import TemplateView, ListView, View
+from django.views.generic import TemplateView, ListView
 from django.views.generic.edit import CreateView, FormView
 from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect
@@ -67,18 +67,31 @@ class SurveyPublish(TemplateView):
         context['survey'].published = True
         context['survey'].save()
 
-        return redirect('surveys-list')
+        return redirect('surveys-list-run')
 
 
-class SurveyList(ListView):
+class SurveyListEdit(ListView):
     model = SurveyFormEntry
     template_name = "survey_list.html"
     context_object_name = 'surveys'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['published'] = self.request.GET.get('published', 'f')
-        context['surveys'] = context['surveys'].filter(published=context['published'])
+        context['surveys'] = context['surveys'].filter(published=False)
+        context['published'] = False
+
+        return context
+
+
+class SurveyListRun(ListView):
+    model = SurveyFormEntry
+    template_name = "survey_list.html"
+    context_object_name = 'surveys'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['surveys'] = context['surveys'].filter(published=True)
+        context['published'] = True 
 
         return context
 
@@ -127,8 +140,6 @@ class Signup(FormView):
         form = self.form_class(request.POST, instance=superuser)
         if form.is_valid():
             form.save()
-            username = form.cleaned_data.get('username')
-            raw_password = form.cleaned_data.get('password1')
             return redirect('login')
 
         return render(request, self.template_name, {'form': form})

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -75,6 +75,13 @@ class SurveyList(ListView):
     template_name = "survey_list.html"
     context_object_name = 'surveys'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['published'] = self.request.GET.get('published', 'f')
+        context['surveys'] = context['surveys'].filter(published=context['published'])
+
+        return context
+
 
 class SurveySubmittedList(TemplateView):
     template_name = "survey_submitted_list.html"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,7 +141,7 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
-LOGIN_REDIRECT_URL = 'surveys-list'
+LOGIN_REDIRECT_URL = 'surveys-list-run'
 
 FOBI_DEFAULT_THEME = 'foundation5'
 FOBI_THEME_FOOTER_TEXT = gettext.gettext('')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,6 +3,19 @@ from django.urls import reverse
 
 
 @pytest.mark.django_db
+def test_survey_list_run(client, user, survey_form_entry):
+    client.force_login(user)
+    url = reverse('surveys-list')
+    url += '?published=f'
+    response = client.get(url)
+
+    surveys = response.context['surveys']
+
+    assert response.status_code == 200
+    assert len(surveys) == 1
+
+
+@pytest.mark.django_db
 def test_survey_publish(client, survey_form_entry):
     assert not survey_form_entry.published
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,16 +3,27 @@ from django.urls import reverse
 
 
 @pytest.mark.django_db
-def test_survey_list_run(client, user, survey_form_entry):
+def test_survey_list_edit(client, user, survey_form_entry):
     client.force_login(user)
-    url = reverse('surveys-list')
-    url += '?published=f'
+    url = reverse('surveys-list-edit')
     response = client.get(url)
 
     surveys = response.context['surveys']
 
     assert response.status_code == 200
     assert len(surveys) == 1
+
+
+@pytest.mark.django_db
+def test_survey_list_run(client, user, survey_form_entry):
+    client.force_login(user)
+    url = reverse('surveys-list-run')
+    response = client.get(url)
+
+    surveys = response.context['surveys']
+
+    assert response.status_code == 200
+    assert len(surveys) == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

This PR closes both #32 and #54 by checking for a `published` value in the SurveyList view. I feel like there might be a more elegant way to modify `urls.py` to handle this!

## Testing Instructions

 * If you don't already have it, create the database: `pg_restore -C -j4 --no-owner just-spaces.dump | psql`
* Migrate: `python manage.py migrate`
* Login as testuser (password in the DataMade LastPass under "Just Spaces Staging")
* Create a couple new surveys. Publish at least one. Is the interface reasonably intuitive?

Connects #32 and #54 