### PR TITLE
Handle required PLDP metadata

### DIFF
--- a/fobi_custom/plugins/form_elements/fields/metadata/method/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/metadata/method/forms.py
@@ -16,7 +16,7 @@ class PLDPSurveyMethodForm(forms.Form, BaseFormFieldPluginForm):
         ("name", "name"),
         ("default", ""),
         ("help_text", ""),
-        ("required", False),
+        ("required", True),
     ]
 
     label = forms.CharField(label="Label",

--- a/fobi_custom/plugins/form_elements/fields/metadata/representation/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/metadata/representation/forms.py
@@ -16,7 +16,7 @@ class PLDPSurveyRepresentationForm(forms.Form, BaseFormFieldPluginForm):
         ("name", "name"),
         ("default", ""),
         ("help_text", ""),
-        ("required", False),
+        ("required", True),
     ]
 
     label = forms.CharField(label="Label",

--- a/fobi_custom/plugins/form_elements/fields/metadata/time_start/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/metadata/time_start/forms.py
@@ -13,7 +13,7 @@ class TimeStartForm(forms.Form, BaseFormFieldPluginForm):
         ("label", "What is the start time of this survey?"),
         ("name", "name"),
         ("help_text", ""),
-        ("required", False),
+        ("required", True),
     ]
 
     label = forms.CharField(label="Label",

--- a/fobi_custom/plugins/form_elements/fields/metadata/time_stop/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/metadata/time_stop/forms.py
@@ -13,7 +13,7 @@ class TimeStopForm(forms.Form, BaseFormFieldPluginForm):
         ("label", "What is the stop time of this survey?"),
         ("name", "name"),
         ("help_text", ""),
-        ("required", False),
+        ("required", True),
     ]
 
     label = forms.CharField(label="Label",

--- a/fobi_custom/plugins/form_handlers/collect_data/fobi_form_handlers.py
+++ b/fobi_custom/plugins/form_handlers/collect_data/fobi_form_handlers.py
@@ -45,11 +45,8 @@ class CollectDataPlugin(FormHandlerPlugin):
 
             new_survey = Survey.objects.create(**new_survey_info)
 
-            # total = self.get_saved_data('total', 1)
-
             new_survey_row = SurveyRow.objects.create(
                 survey=new_survey,
-                # total=total
             )
 
             meta_element_names = [name for (name, default) in meta_elements]

--- a/fobi_custom/plugins/form_handlers/collect_data/fobi_form_handlers.py
+++ b/fobi_custom/plugins/form_handlers/collect_data/fobi_form_handlers.py
@@ -45,11 +45,11 @@ class CollectDataPlugin(FormHandlerPlugin):
 
             new_survey = Survey.objects.create(**new_survey_info)
 
-            total = self.get_saved_data('total', 1)
+            # total = self.get_saved_data('total', 1)
 
             new_survey_row = SurveyRow.objects.create(
                 survey=new_survey,
-                total=total
+                # total=total
             )
 
             meta_element_names = [name for (name, default) in meta_elements]

--- a/justspaces/settings.py
+++ b/justspaces/settings.py
@@ -63,7 +63,7 @@ INSTALLED_APPS = [
     'fobi.contrib.plugins.form_elements.fields.time',
 
     # custom metadata form elements
-    'fobi_custom.plugins.form_elements.fields.metadata.total',
+    # 'fobi_custom.plugins.form_elements.fields.metadata.total',
     'fobi_custom.plugins.form_elements.fields.metadata.time_start',
     'fobi_custom.plugins.form_elements.fields.metadata.time_stop',
     'fobi_custom.plugins.form_elements.fields.metadata.time_character',

--- a/justspaces/settings.py
+++ b/justspaces/settings.py
@@ -63,7 +63,6 @@ INSTALLED_APPS = [
     'fobi.contrib.plugins.form_elements.fields.time',
 
     # custom metadata form elements
-    # 'fobi_custom.plugins.form_elements.fields.metadata.total',
     'fobi_custom.plugins.form_elements.fields.metadata.time_start',
     'fobi_custom.plugins.form_elements.fields.metadata.time_stop',
     'fobi_custom.plugins.form_elements.fields.metadata.time_character',

--- a/surveys/templates/survey_submitted_detail.html
+++ b/surveys/templates/survey_submitted_detail.html
@@ -13,7 +13,6 @@
     <thead>
       <tr>
         <th scope="col">Time Submitted</th>
-        <th scope="col">Row Total</th>
         {% for question in questions %}
           <th scope="col">{{question}}</th>
         {% endfor %}
@@ -23,7 +22,6 @@
       {% for survey in surveys_submitted %}
         <tr>
           <td>{{survey.time_stop}}</td>
-          <td>{{survey.row.total}}</td>
           {% for component in survey.components %}
             <td>{{component.saved_data}}</td>
           {% endfor %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,6 @@ def survey(db, location, study):
 @pytest.mark.django_db
 def survey_row(db, survey):
     survey_row = SurveyRow.objects.create(
-        total=5,
         survey=survey,
     )
 

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -51,7 +51,7 @@ def test_data_handler(survey_form_entry, location, study, form_element_float,
     assert survey.study == study
 
     assert row.id
-    assert row.total
+    assert not row.total
     assert row.survey == survey
 
     assert component.id


### PR DESCRIPTION
## Overview

Following the discussion in #88, this PR removes `Total` as a survey question and makes `time_start`, `time_stop`, `representation`, and `method` questions automatically required fields once they are added to a survey. 

If we want to always create observational surveys with these fields, that should be handled once templated surveys (#90) have been implemented. Until we've figured out the templating and talked to UCD, I don't see a reason to spend more time making these elements required on every Observational survey.
 
## Testing Instructions

* If you don't already have it, create the database: `pg_restore -C -j4 --no-owner just-spaces.dump | psql`
* Migrate: `python manage.py migrate`
* Login as testuser (password in the DataMade LastPass under "Just Spaces Staging")
* Create a new Observational survey
* Add `time_start`, `time_stop`, `representation`, and `method` questions. Are they automatically created as required questions?

 Closes #88 