### PR TITLE
Issue 106

### DIFF
--- a/fobi_custom/override_theme/templates/override_theme/edit_form_entry_ajax.html
+++ b/fobi_custom/override_theme/templates/override_theme/edit_form_entry_ajax.html
@@ -9,10 +9,10 @@
 
    <ul class="nav nav-tabs" id="surveyTabs" role="tablist">
      <li class="nav-item">
-       <a class="nav-link active" id="surveyQuestionsTab" data-toggle="tab" href="#survey-questions" role="tab" aria-controls="survey-questions" aria-selected="true">Questions</a>
+       <a class="nav-link active" id="surveyQuestionsTab" href="{% url 'fobi.edit_form_entry' form_entry.surveyformentry.pk %}" aria-controls="survey-questions" aria-selected="true">Questions</a>
      </li>
      <li class="nav-item">
-       <a class="nav-link" id="surveyPropertiesTab" data-toggle="tab" href="#survey-properties" role="tab" aria-controls="survey-properties" aria-selected="false">Properties</a>
+       <a class="nav-link" id="surveyPropertiesTab" href="{% url 'survey-properties-edit' form_entry.surveyformentry.pk %}" aria-controls="survey-properties" aria-selected="false">Properties</a>
      </li>
    </ul>
 

--- a/surveys/templates/survey_properties_edit.html
+++ b/surveys/templates/survey_properties_edit.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% load i18n fobi_tags %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="col col-lg-11 card">
+  <div class="card-body">
+
+   <h2 class="card-title">{% trans "Edit" %} <span class="font-italic">{{form_object}}</span></h2>
+   <small class="form-text text-muted">Add, edit, delete, and reorder survey questions</small>
+   <br />
+
+   <ul class="nav nav-tabs" id="surveyTabs" role="tablist">
+     <li class="nav-item">
+       <a class="nav-link" id="surveyQuestionsTab" href="{% url 'fobi.edit_form_entry' form_object.pk %}" aria-controls="survey-questions" aria-selected="true">Questions</a>
+     </li>
+     <li class="nav-item">
+       <a class="nav-link active" id="surveyPropertiesTab" href="{% url 'survey-properties-edit' form_object.pk %}" aria-controls="survey-properties" aria-selected="false">Properties</a>
+     </li>
+   </ul>
+
+   <div class="tab-content" id="surveyTabsContent">
+
+     <div class="tab-pane fade show active" id="survey-properties" role="tabpanel" aria-labelledby="survey-properties">
+
+       <div class="panel panel-default">
+          <div class="panel-body">
+            <br />
+            {% crispy form %}
+          </div>
+        </div>
+
+     </div>
+
+   </div>
+  </div>
+ </div>
+
+{% endblock %}

--- a/surveys/urls.py
+++ b/surveys/urls.py
@@ -11,7 +11,7 @@ from django.contrib.auth.decorators import login_required
 from surveys.views import AgencyCreate, LocationCreate, StudyCreate, \
                             StudyAreaCreate, SurveyCreate, SurveyPublish, \
                             SurveyListEdit, SurveyListRun, Signup, SurveySubmittedList, \
-                            SurveySubmittedDetail
+                            SurveySubmittedDetail, SurveyPropertiesEdit
 import fobi.views
 
 urlpatterns = [
@@ -91,6 +91,11 @@ urlpatterns = [
     url(_(r'^surveys/edit/(?P<form_entry_id>\d+)/$'),
         view=fobi.views.edit_form_entry,
         name='fobi.edit_form_entry'),
+
+    # Edit survey properties
+    url(_(r'^surveys/edit/(?P<pk>\d+)/properties/$'),
+        view=SurveyPropertiesEdit.as_view(),
+        name='survey-properties-edit'),
 
     # Delete survey
     url(_(r'^surveys/delete/(?P<form_entry_id>\d+)/$'),

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -1,6 +1,6 @@
 import json
 
-from django.views.generic import TemplateView, ListView
+from django.views.generic import TemplateView, ListView, UpdateView
 from django.views.generic.edit import CreateView, FormView
 from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect
@@ -133,6 +133,19 @@ class SurveyCreate(CreateView):
 
     def get_success_url(self):
         form_entry_id = self.object.formentry_ptr_id
+        success_url = reverse_lazy('fobi.edit_form_entry', kwargs={'form_entry_id': form_entry_id})
+
+        return str(success_url)
+
+
+class SurveyPropertiesEdit(UpdateView):
+    model = SurveyFormEntry
+    template_name = "survey_properties_edit.html"
+    form_class = SurveyCreateForm
+    context_object_name = 'form_object'
+
+    def get_success_url(self):
+        form_entry_id = self.object.pk
         success_url = reverse_lazy('fobi.edit_form_entry', kwargs={'form_entry_id': form_entry_id})
 
         return str(success_url)

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -135,7 +135,7 @@ class SurveyCreate(CreateView):
         form_entry_id = self.object.formentry_ptr_id
         success_url = reverse_lazy('fobi.edit_form_entry', kwargs={'form_entry_id': form_entry_id})
 
-        return str(success_url)
+        return success_url
 
 
 class SurveyPropertiesEdit(UpdateView):
@@ -148,7 +148,7 @@ class SurveyPropertiesEdit(UpdateView):
         form_entry_id = self.object.pk
         success_url = reverse_lazy('fobi.edit_form_entry', kwargs={'form_entry_id': form_entry_id})
 
-        return str(success_url)
+        return success_url
 
 
 class SurveyPublish(TemplateView):


### PR DESCRIPTION
## Overview

Closes #106. This PR creates a view for editing survey properties. It uses the same form as the `SurveyCreate` view, and user will be automatically selected and hidden in #140. 

## Testing Instructions

* Create a new survey
* The site should take you to the "Edit Survey" page. Can you find where to change its properties? When you save them, does it bring you back to the "Questions" tab?
