### PR TITLE
Ensure that ACS data selections get saved

### DIFF
--- a/surveys/templates/survey_submitted_detail.html
+++ b/surveys/templates/survey_submitted_detail.html
@@ -198,6 +198,37 @@
       }
     });
 
+    function displayAcsSeries(selectbox) {
+      /**
+       * Given a selectbox selector representing choices for ACS data, display
+       * that ACS data on the chart.
+       */
+      var primarySourceId = $(selectbox).parents(chartContainer).find('select[name$="primary_source"]').val();
+      var chartId = $(selectbox).parents(chartContainer).find('.highcharts-chart').first().attr('id');
+      charts.removeAllAcsSeries(chartId);
+
+      var geographies = $(selectbox).find('option:selected').map(function() {
+        return {id: $(this).val(), label: $(this).text()};
+      });
+      if (geographies.length > 0) {
+        for (var i=0; i<geographies.length; i++) {
+          var geography = geographies[i];
+          var dataUrl = "{% url 'acs' %}?census_area=" + geography.id + "&primary_source=" + primarySourceId;
+          // Since the following code executes asynchronously, wrap it in an immediately
+          // executed function in order to ensure that the proper geography label is
+          // applied. See: https://stackoverflow.com/a/15347771
+          (function(geographyLabel) {
+            $.getJSON(dataUrl).done(function(acsData) {
+              charts.addAcsSeries(chartId, acsData, geographyLabel);
+            }).fail(function(jqxhr, textStatus, error) {
+              var err = textStatus + ", " + error;
+              console.log("Request to " + dataUrl + " failed: " + err);
+            });
+          })(geography.label);
+        }
+      }
+    }
+
     // Initialize sortable chart widgets
     $('#sortable-chart-container').sortable({
       handle: ".portlet-handle",
@@ -268,43 +299,24 @@
       }
     });
 
-    $('form').on('change', censusSelectBox, function(event) {
+    $('form').on('change', censusSelectBox, function() {
       // Listen to ACS data source multiselect boxes, and update the charts when the
       // data source changes
-      var primarySourceId = $(this).parents(chartContainer).find('select[name$="primary_source"]').val();
-      var chartId = $(this).parents(chartContainer).find('.highcharts-chart').first().attr('id');
-      charts.removeAllAcsSeries(chartId);
-
-      var geographies = $(this).find('option:selected').map(function() {
-        return {id: $(this).val(), label: $(this).text()};
-      });
-      if (geographies.length > 0) {
-        for (var i=0; i<geographies.length; i++) {
-          var geography = geographies[i];
-          var dataUrl = "{% url 'acs' %}?census_area=" + geography.id + "&primary_source=" + primarySourceId;
-          // Since the following code executes asynchronously, wrap it in an immediately
-          // executed function in order to ensure that the proper geography label is
-          // applied. See: https://stackoverflow.com/a/15347771
-          (function(geographyLabel) {
-            $.getJSON(dataUrl).done(function(acsData) {
-              charts.addAcsSeries(chartId, acsData, geographyLabel);
-            }).fail(function(jqxhr, textStatus, error) {
-              var err = textStatus + ", " + error;
-              console.log("Request to " + dataUrl + " failed: " + err);
-            });
-          })(geography.label);
-        }
-      }
+      displayAcsSeries(this);
     });
 
     // Load visible charts
-    $(chartContainer).filter(':visible').find('select[name$="primary_source"]').each(function() {
+    var visibleChartForms = $(chartContainer).filter(':visible');
+    visibleChartForms.find('select[name$="primary_source"]').each(function() {
       var dataSourceId = $(this).val();
       var chartId = $(this).parents(chartContainer).find('.highcharts-chart').first().attr('id');
       if (dataSourceId != '') {
         var chartTitle = $(this).find('option:selected').html();
         charts.loadChart(chartId, chartTitle, dataSourceId);
       }
+    });
+    visibleChartForms.find(censusSelectBox).each(function() {
+      displayAcsSeries(this);
     });
 
     $('#clear-charts').click(function() {

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -475,6 +475,7 @@ class SurveySubmittedDetail(TemplateView):
                     survey_chart = form.save(commit=False)
                     survey_chart.form_entry = form.form_entry
                     survey_chart.save()
+                    form.save_m2m()  # Save CensusArea related objects
             messages.success(request, 'Charts saved!')
         else:
             messages.error(request, 'Chart validation failed! See charts below for more detail.')


### PR DESCRIPTION
## Overview

In the course of addressing #165, @beamalsky noticed that ACS selections weren't getting saved in the DAD. This chart updates the route and frontend scripts to make sure that ACS data gets saved and displayed on first load.

## Testing Instructions

* Create a chart with an ACS-compatible question (like `How old are you?`)
* Select two ACS geographies
* Save the charts
* Confirm that when you reload the page, the chart displays the ACS data 
