### PR TITLE
Constrain content width on large screens

### DIFF
--- a/surveys/static/css/custom.css
+++ b/surveys/static/css/custom.css
@@ -212,7 +212,7 @@ a.article:hover {
 }
 
 .content {
-  width: 95%;
+  width: 80%;
   padding: 40px;
   min-height: 100vh;
   transition: all 0.3s;
@@ -436,6 +436,10 @@ a.article:hover {
   div.dataTables_wrapper div.dataTables_info,
   div.dataTables_wrapper div.dataTables_paginate {
       text-align: left !important;
+  }
+
+  .content {
+    width: 95%;
   }
 }
 


### PR DESCRIPTION
## Overview

Make sure that long content isn't too wide on large screens.

## Testing Instructions

* Visit a collected data view with lots of columns and confirm that the page doesn't require a horizontal scroll
* Use browser dev tools to preview the site on mobile and confirm that the width still looks good
