### PR TITLE
Call select2 when censusContainer is made visible

### DIFF
--- a/surveys/templates/survey_submitted_detail.html
+++ b/surveys/templates/survey_submitted_detail.html
@@ -112,7 +112,6 @@ Use this page to download, view, and construct analyses of your collected survey
   <script src="{% static 'js/jquery-ui-1.21.1.min.js' %}" type="text/javascript"></script>
   <script>
     $(document).ready(function () {
-      $('.basic-multiple').select2();
       var table = $('#survey-submitted-detail').DataTable({
         buttons: [{
           extend: 'csv',
@@ -188,6 +187,8 @@ Use this page to download, view, and construct analyses of your collected survey
         }
       }
       if (isAcsCompatibleType) {
+        // initialize select2 just before a Census container is shown
+        $censusContainer.find(".basic-multiple").select2();
         $censusContainer.show();
       } else {
         $censusContainer.hide();


### PR DESCRIPTION
## Overview

This PR solves the bug described in #189: `CensusArea select widget won't display options when adding a new chart`. @jeancochrane was right about the cause—Select2 fields initialized on the hidden form template have no options—and I fixed the bug by moving the `.select2()` call to `toggleCensusContainerVisibility`, where it will reliably be called before the Census container is shown.

Closes #189.


## Testing Instructions

 * View collected data of a survey with at least one ACS question and at least one run
* Make sure that existing charts correctly display the `Compare to Census:` field
* Create a new chart, select an ACS question, and make sure it  correctly displays the `Compare to Census:` field
