### PR TITLE
Chart colors

### DIFF
--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -10,4 +10,6 @@ set -euo pipefail
 mkdir -p /home/datamade/just-spaces
 
 # Decrypt files encrypted with blackbox
-cd /opt/codedeploy-agent/deployment-root/$DEPLOYMENT_GROUP_ID/$DEPLOYMENT_ID/deployment-archive/ && chown -R datamade.datamade . && sudo -H -u datamade blackbox_postdeploy
+apt-get update
+apt-get install -y gnupg2
+cd /opt/codedeploy-agent/deployment-root/$DEPLOYMENT_GROUP_ID/$DEPLOYMENT_ID/deployment-archive/ && chown -R datamade.datamade . && sudo -H -u datamade GPG=gpg2 blackbox_postdeploy

--- a/surveys/static/js/charts.js
+++ b/surveys/static/js/charts.js
@@ -540,7 +540,7 @@ function binValue(value, bins) {
  * @param {Array} a items An array containing the items.
  */
 function shuffle(a) {
-    for (let i = a.length - 1; i > 0; i--) {
+    for (var i = a.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [a[i], a[j]] = [a[j], a[i]];
     }

--- a/surveys/static/js/charts.js
+++ b/surveys/static/js/charts.js
@@ -69,7 +69,7 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
   var series = [{
     name: this.getSeriesName(),
     data: [],
-    color: '#e94e0c',
+    color: '#a1bfa2',
   }];
   chartData.forEach(function(data) {
     // chartData elements are stored as an Array where the first element is the
@@ -95,16 +95,16 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
   }
   var chartType = (isCount && this.surveys.length >= 5) ? 'boxplot' : 'column';
   var ACSColors = [
-      '#015c75',
-      '#eb549e',
-      '#e4c23f',
-      '#cde8ce',
-      '#dcc3ce',
-      '#e9ac92',
-      '#d6edf4',
-      '#546455',
-      '#a1bfa2',
-      '#e48b8b'
+    '#ffd700',
+    '#ffb14e',
+    '#fa8775',
+    '#eb549e',
+    '#e94e0c',
+    '#cd58bb',
+    '#9e86d7',
+    '#015c75',
+    '#cde8ce',
+    '#d6edf4'
   ]
 
   shuffle(ACSColors);

--- a/surveys/static/js/charts.js
+++ b/surveys/static/js/charts.js
@@ -68,7 +68,8 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
   var categories = [];
   var series = [{
     name: this.getSeriesName(),
-    data: []
+    data: [],
+    color: '#e94e0c',
   }];
   chartData.forEach(function(data) {
     // chartData elements are stored as an Array where the first element is the
@@ -93,6 +94,21 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
     yAxisLabel = '% of responses';
   }
   var chartType = (isCount && this.surveys.length >= 5) ? 'boxplot' : 'column';
+  var ACSColors = [
+      '#015c75',
+      '#eb549e',
+      '#e4c23f',
+      '#cde8ce',
+      '#dcc3ce',
+      '#e9ac92',
+      '#d6edf4',
+      '#546455',
+      '#a1bfa2',
+      '#e48b8b'
+  ]
+
+  shuffle(ACSColors);
+
   // Initialize a Highcharts chart
   Highcharts.chart(chartId, {
     chart: {
@@ -114,7 +130,8 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
     legend: {
       enabled: true
     },
-    series: series
+    series: series,
+    colors: ACSColors
   });
 }
 
@@ -516,4 +533,16 @@ function binValue(value, bins) {
     binnedValue = String(bins[bins.length - 1]) + '+';
   }
   return binnedValue;
+}
+
+/**
+ * Shuffles array in place. ES6 version
+ * @param {Array} a items An array containing the items.
+ */
+function shuffle(a) {
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
 }


### PR DESCRIPTION
## Overview

This PR fixes the bug described in #188: `ACS charts can choose the same color as primary_source`.

To get around this, I set `primary source` to a consistent color ("Just Spaces mid-green"), and give the ACS series a set of colors to choose from. These can't repeat, as ACS series are torn down and recreated whenever they change. I think this also has the advantage of consistently visually distinguishing collected data from ACS data. If this project is extended to handle multiple series of collected data on the same chart this will have to be updated, but my understanding is that that's not on the horizon for the current scope. 

In the process I've also added a color palette for the charts to bring it more in line with the rest of the site and away from the HighCharts defaults!

It should look like this:

![Screen Shot 2019-07-02 at 4 14 16 PM](https://user-images.githubusercontent.com/1094243/60547249-cdc18880-9ce4-11e9-98c4-e4ace616bbba.png)

This also modifies `before_install.sh` to handle blackbox being updated on the server, as documented at https://github.com/datamade/deploy-a-site/pull/69

Closes #188 

## Testing Instructions

 * Create a new chart with an ACS-eligible question
* Add and remove some CensusAreas. Make sure the colors never repeat!
