### PR TITLE
Support charts for ZIP code questions in the DAD

### DIFF
--- a/fobi_custom/plugins/form_elements/fields/types.py
+++ b/fobi_custom/plugins/form_elements/fields/types.py
@@ -7,8 +7,8 @@ from fobi.utils import get_registered_form_element_plugins
 COUNT_TYPES = [
     'temperature_c', 'decimal', 'float', 'integer'
 ]
-# "Distribution" types represent a single value, and will be displayed as the
-# as percentiles (a distribution) of all recorded values. This is useful since
+# "Distribution" types represent a single value, and will be displayed as
+# percentiles (a distribution) of all recorded values. This is useful since
 # these types are expected to have a small set of potential responses.
 DISTRIBUTION_TYPES = ['location_zip_home', 'location_zip_work']
 # "Observational" types represent counts for multiple choices, and will

--- a/fobi_custom/plugins/form_elements/fields/types.py
+++ b/fobi_custom/plugins/form_elements/fields/types.py
@@ -7,6 +7,10 @@ from fobi.utils import get_registered_form_element_plugins
 COUNT_TYPES = [
     'temperature_c', 'decimal', 'float', 'integer'
 ]
+# "Distribution" types represent a single value, and will be displayed as the
+# as percentiles (a distribution) of all recorded values. This is useful since
+# these types are expected to have a small set of potential responses.
+DISTRIBUTION_TYPES = ['location_zip_home', 'location_zip_work']
 # "Observational" types represent counts for multiple choices, and will
 # be aggregated and displayed as percentiles (a distribution).
 OBSERVATIONAL_TYPES = [
@@ -36,8 +40,10 @@ FREE_RESPONSE_INTERCEPT_TYPES = list(FREE_RESPONSE_INTERCEPT_BINS.keys())
 
 ALL_TYPES = [plugin[0] for plugin in get_registered_form_element_plugins()]
 # All valid types merged into one list, for easy validation.
-ALL_VALID_TYPES = (COUNT_TYPES + OBSERVATIONAL_TYPES + OBSERVATIONAL_COUNT_TYPES +
-                   INTERCEPT_TYPES + FREE_RESPONSE_INTERCEPT_TYPES)
+ALL_VALID_TYPES = (
+    COUNT_TYPES + DISTRIBUTION_TYPES + OBSERVATIONAL_TYPES +
+    OBSERVATIONAL_COUNT_TYPES + INTERCEPT_TYPES + FREE_RESPONSE_INTERCEPT_TYPES
+)
 # All types that cannot be displayed as charts.
 ALL_INVALID_TYPES = list(set(ALL_TYPES) - set(ALL_VALID_TYPES))
 

--- a/surveys/static/js/charts.js
+++ b/surveys/static/js/charts.js
@@ -40,12 +40,13 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
   }
 
   var isCount = this.types.count.indexOf(resultType) > -1;
+  var isDistribution = this.types.distribution.indexOf(resultType) > -1;
   var isObservational = this.types.observational.indexOf(resultType) > -1;
   var isObservationalCount = this.types.observationalCount.indexOf(resultType) > -1;
   var isIntercept = this.types.intercept.indexOf(resultType) > -1;
   var isFreeResponseIntercept = this.types.freeResponseIntercept.indexOf(resultType) > -1;
 
-  if (!(isCount || isObservational || isObservationalCount || isIntercept || isFreeResponseIntercept)) {
+  if (!(isCount || isDistribution || isObservational || isObservationalCount || isIntercept || isFreeResponseIntercept)) {
     // The data object needs to be one of the valid types
     throw new Error('Not a valid chart type: ' + resultType);
   } else {
@@ -53,6 +54,8 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
     var chartData = [];
     if (isCount) {
       chartData = this._getCountChartData(dataSourceId, chartTitle);
+    } else if (isDistribution) {
+      chartData = this._getDistributionChartData(dataSourceId, chartTitle);
     } else if (isObservational) {
       chartData = this._getObservationalChartData(dataSourceId);
     } else if (isObservationalCount) {
@@ -196,6 +199,34 @@ ChartHelper.prototype._getCountChartData = function(dataSourceId, chartTitle) {
     }
   }
   var aggFunc = (this.surveys.length >= 5) ? quintiles : medians;
+  return this._getChartData(dataSourceId, initChartDataFunc, castFunc, updateChartDataFunc, aggFunc);
+}
+
+ChartHelper.prototype._getDistributionChartData = function(dataSourceId, chartTitle) {
+  /**
+   * Get chart data for a chart of the "count" type.
+   * @param {String} dataSourceId - The ID of the primary data source to display.
+   * @param {String} chartTitle - The title of the chart to display.
+   */
+  function initChartDataFunc() { return []; }
+  var castFunc = String;
+  function updateChartDataFunc(chartData, savedData) {
+    var categoryFound = false;
+    // If an entry for this category exists in the chartData array, increment its counter
+    for (var i = 0; i < chartData.length; i++) {
+      var categoryName = chartData[i][0];
+      if (categoryName === savedData) {
+        chartData[i][1] += 1;
+        categoryFound = true;
+        break;
+      }
+    }
+    if (!categoryFound) {
+      // Insert an entry for this count in the chartData array
+      chartData.push([savedData, 1]);
+    }
+  }
+  var aggFunc = percentiles;
   return this._getChartData(dataSourceId, initChartDataFunc, castFunc, updateChartDataFunc, aggFunc);
 }
 

--- a/surveys/static/js/charts.js
+++ b/surveys/static/js/charts.js
@@ -55,7 +55,7 @@ ChartHelper.prototype.loadChart = function(chartId, chartTitle, dataSourceId) {
     if (isCount) {
       chartData = this._getCountChartData(dataSourceId, chartTitle);
     } else if (isDistribution) {
-      chartData = this._getDistributionChartData(dataSourceId, chartTitle);
+      chartData = this._getDistributionChartData(dataSourceId);
     } else if (isObservational) {
       chartData = this._getObservationalChartData(dataSourceId);
     } else if (isObservationalCount) {
@@ -202,11 +202,10 @@ ChartHelper.prototype._getCountChartData = function(dataSourceId, chartTitle) {
   return this._getChartData(dataSourceId, initChartDataFunc, castFunc, updateChartDataFunc, aggFunc);
 }
 
-ChartHelper.prototype._getDistributionChartData = function(dataSourceId, chartTitle) {
+ChartHelper.prototype._getDistributionChartData = function(dataSourceId) {
   /**
-   * Get chart data for a chart of the "count" type.
+   * Get chart data for a chart of the "distribution" type.
    * @param {String} dataSourceId - The ID of the primary data source to display.
-   * @param {String} chartTitle - The title of the chart to display.
    */
   function initChartDataFunc() { return []; }
   var castFunc = String;
@@ -226,7 +225,7 @@ ChartHelper.prototype._getDistributionChartData = function(dataSourceId, chartTi
       chartData.push([savedData, 1]);
     }
   }
-  var aggFunc = percentiles;
+  var aggFunc = sortedPercentiles;
   return this._getChartData(dataSourceId, initChartDataFunc, castFunc, updateChartDataFunc, aggFunc);
 }
 
@@ -531,6 +530,18 @@ function percentiles(categories) {
    */
   var total = categories.reduce(function(acc, category) { return acc + category[1] }, 0);
   return categories.map(function(category) { return [category[0], Math.round((category[1] / total) * 100)] })
+}
+
+function sortedPercentiles(categories) {
+  /**
+   * Given an array map of categories:counts, return percentiles for each category
+   * in an array where each category is sorted as an integer (e.g. a zip code).
+   * @param {Array} categories - A nested array of numbers acting as a Map, where
+   *                             the first element represents a category name and the
+   *                             second element represents its value.
+   */
+  categories.sort(function(first, second) {return Number(first[0]) - Number(second[0])})
+  return percentiles(categories)
 }
 
 function binValue(value, bins) {

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -500,6 +500,7 @@ class SurveySubmittedDetail(TemplateView):
         # Fobi types, bins, and ACS variables for use in charting
         context['types'] = json.dumps({
             'count': fobi_types.COUNT_TYPES,
+            'distribution': fobi_types.DISTRIBUTION_TYPES,
             'observational': fobi_types.OBSERVATIONAL_TYPES,
             'observationalCount': fobi_types.OBSERVATIONAL_COUNT_TYPES,
             'intercept': fobi_types.INTERCEPT_TYPES,


### PR DESCRIPTION
## Overview

Closes #184.

Support simple charts for ZIP code location questions in the data analysis designer, showing the distribution of answers:

<img width="944" alt="Screen Shot 2019-07-03 at 12 07 30 PM" src="https://user-images.githubusercontent.com/14170650/60611141-37946d80-9d8b-11e9-8668-169ea0fac63b.png">

## Testing Instructions

* Create an Intercept survey with work/home ZIP code location questions and run it a few times
* Navigate to `View collected data` for your survey and confirm you can create charts out of your ZIP code location questions
