### PR TITLE
Filter for deactivated models

### DIFF
--- a/surveys/forms.py
+++ b/surveys/forms.py
@@ -146,7 +146,10 @@ class StudyCreateForm(JustSpacesForm):
         super(StudyCreateForm, self).__init__(*args, **kwargs)
         self.create_default_helper()
         self.fields['areas'].widget.attrs['class'] = 'basic-multiple'
+
         self.fields['agency'].initial = pldp_models.Agency.objects.first()
+        self.fields['agency'].queryset = pldp_models.Agency.objects.filter(is_active='t')
+
         self.fields['title'].required = True
 
     class Meta:
@@ -163,7 +166,10 @@ class SurveyCreateForm(JustSpacesForm):
     def __init__(self, *args, **kwargs):
         super(SurveyCreateForm, self).__init__(*args, **kwargs)
         self.fields['study'].required = True
+        self.fields['study'].queryset = pldp_models.Study.objects.filter(is_active='t')
+
         self.fields['location'].required = True
+        self.fields['location'].queryset = pldp_models.Location.objects.filter(is_active='t')
 
         self.fields['name'].help_text = "Survey names should be unique and memorable."
         self.fields['type'].help_text = "This selection will determine which questions \


### PR DESCRIPTION
## Overview

Closes #176. A quick PR that fixes something that might appear like a bug! Makes sure deactivated records of the following types won't show up in dropdowns:

- Study and Location in "Create new Survey"
- Agency in "Create new Study"

## Testing Instructions

 * Go to "Create new Survey". Deactivate one of the Study and Location records each and make sure they disappear.
* Do the same for Agency on the "Create new Study" view