### PR TITLE
Fix responsive tables

### DIFF
--- a/surveys/templates/agency_detail.html
+++ b/surveys/templates/agency_detail.html
@@ -7,22 +7,24 @@
 {% block subhead %}Contact: <b>{{agency.email}}</b>{% endblock %}
 
 {% block card_content %}
-  <table id="agency-detail" class="table table-striped table-responsive-sm table-bordered">
-  <thead>
-  </thead>
-  <tbody>
+  <div class="table-responsive">
+    <table id="agency-detail" class="table table-striped table-bordered">
+    <thead>
+    </thead>
+    <tbody>
 
-    {% for label, content in rows %}
-      {% if content %}
-      <tr>
-        <td style="width: 30%"><b>{{label}}</b></td>
-        <td>{{content}}</td>
-      </tr>
-      {% endif %}
-    {% endfor %}
+      {% for label, content in rows %}
+        {% if content %}
+        <tr>
+          <td style="width: 30%"><b>{{label}}</b></td>
+          <td>{{content}}</td>
+        </tr>
+        {% endif %}
+      {% endfor %}
 
-  </tbody>
-  </table>
+    </tbody>
+    </table>
+  </div>
 
   <a class="btn btn-secondary float-right" href="{% url 'agencies-deactivate' agency.id %}">Delete agency</a>
   <a class="btn btn-link float-right" href="{% url 'agencies-list' %}">Back to agency list</a>

--- a/surveys/templates/agency_list.html
+++ b/surveys/templates/agency_list.html
@@ -22,24 +22,26 @@ record containing its key attributes and reliable contact information.
 {% endblock %}
 
 {% block card_content %}
-  <table id="agencies-list" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Name</th>
-      <th scope="col">Contact Email</th>
-      <th scope="col" class="text-center">Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for agency in agencies %}
+  <div class="table-responsive">
+    <table id="agencies-list" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td><b><a href="{% url 'agencies-detail' agency.id %}">{{agency.name}}</a></b></td>
-        <td>{{agency.email}}</td>
-        <td class="text-center"><a href="{% url 'agencies-deactivate' agency.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        <th scope="col">Name</th>
+        <th scope="col">Contact Email</th>
+        <th scope="col" class="text-center">Delete</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for agency in agencies %}
+        <tr>
+          <td><b><a href="{% url 'agencies-detail' agency.id %}">{{agency.name}}</a></b></td>
+          <td>{{agency.email}}</td>
+          <td class="text-center"><a href="{% url 'agencies-deactivate' agency.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/census_area_list.html
+++ b/surveys/templates/census_area_list.html
@@ -21,34 +21,36 @@
 {% endblock %}
 
 {% block card_content %}
-  <table id="census-areas-list" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Name</th>
-      <th scope="col" class="text-center">Is preset</th>
-      <th scope="col" class="text-center">Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for census_area in census_areas %}
+  <div class="table-responsive">
+    <table id="census-areas-list" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td>
-          <b>
-            {% if not census_area.is_preset %}
-              <a href="{% url 'census-areas-edit' census_area.id %}">{{census_area.name}}</a>
-            {% else %}
-              <span data-toggle="tooltip" title="Preset census areas cannot be edited." tabindex="0">
-                {{ census_area.name}}
-              </span>
-            {% endif %}
-          </b>
-        </td>
-        <td class="text-center">{% if census_area.is_preset %}<i class="fa fa-fw fa-check-circle" style="color:green"></i>{% endif %}</td>
-        <td class="text-center"><a href="{% url 'census-areas-deactivate' census_area.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        <th scope="col">Name</th>
+        <th scope="col" class="text-center">Is preset</th>
+        <th scope="col" class="text-center">Delete</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for census_area in census_areas %}
+        <tr>
+          <td>
+            <b>
+              {% if not census_area.is_preset %}
+                <a href="{% url 'census-areas-edit' census_area.id %}">{{census_area.name}}</a>
+              {% else %}
+                <span data-toggle="tooltip" title="Preset census areas cannot be edited." tabindex="0">
+                  {{ census_area.name}}
+                </span>
+              {% endif %}
+            </b>
+          </td>
+          <td class="text-center">{% if census_area.is_preset %}<i class="fa fa-fw fa-check-circle" style="color:green"></i>{% endif %}</td>
+          <td class="text-center"><a href="{% url 'census-areas-deactivate' census_area.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/location_detail.html
+++ b/surveys/templates/location_detail.html
@@ -21,22 +21,24 @@
   {% leaflet_map "main" callback="main_map_init" %}
   <br />
 
-  <table id="location-detail" class="table table-striped table-responsive-sm table-bordered">
-  <thead>
-  </thead>
-  <tbody>
+  <div class="table-responsive">
+    <table id="location-detail" class="table table-striped table-bordered">
+    <thead>
+    </thead>
+    <tbody>
 
-    {% for label, content in rows %}
-      {% if content %}
-      <tr>
-        <td style="width: 30%"><b>{{label}}</b></td>
-        <td>{{content}}</td>
-      </tr>
-      {% endif %}
-    {% endfor %}
+      {% for label, content in rows %}
+        {% if content %}
+        <tr>
+          <td style="width: 30%"><b>{{label}}</b></td>
+          <td>{{content}}</td>
+        </tr>
+        {% endif %}
+      {% endfor %}
 
-  </tbody>
-  </table>
+    </tbody>
+    </table>
+  </div>
 
   <a class="btn btn-secondary float-right" href="{% url 'locations-deactivate' location.id %}">Delete location</a>
   <a class="btn btn-link float-right" href="{% url 'locations-list' %}">Back to location list</a>

--- a/surveys/templates/location_list.html
+++ b/surveys/templates/location_list.html
@@ -22,24 +22,26 @@ It can have either a line or area geometry.
 {% endblock %}
 
 {% block card_content %}
-  <table id="locations-list" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Primary Name</th>
-      <th scope="col">Geometry Type</th>
-      <th class="text-center" scope="col">Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for location in locations %}
+  <div class="table-responsive">
+    <table id="locations-list" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td><b><a href="{% url 'locations-detail' location.id %}">{{location.name_primary}}</a></b></td>
-        <td>{{location.geometry_type}}</td>
-        <td class="text-center"><a href="{% url 'locations-deactivate' location.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        <th scope="col">Primary Name</th>
+        <th scope="col">Geometry Type</th>
+        <th class="text-center" scope="col">Delete</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for location in locations %}
+        <tr>
+          <td><b><a href="{% url 'locations-detail' location.id %}">{{location.name_primary}}</a></b></td>
+          <td>{{location.geometry_type}}</td>
+          <td class="text-center"><a href="{% url 'locations-deactivate' location.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/partials/large_card.html
+++ b/surveys/templates/partials/large_card.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-<div class="col col-lg-11 card">
+<div class="col col-lg-12 card">
   <div class="card-body">
 
     <div class="row ml-1">

--- a/surveys/templates/study_detail.html
+++ b/surveys/templates/study_detail.html
@@ -18,22 +18,24 @@
 {% block subhead %}<b>{{study.agency}}</b> study managed by <b>{{study.manager_name}}</b>{% endblock %}
 
 {% block card_content %}
-  <table id="study-detail" class="table table-striped table-responsive-sm table-bordered">
-  <thead>
-  </thead>
-  <tbody>
+  <div class="table-responsive">
+    <table id="study-detail" class="table table-striped table-bordered">
+    <thead>
+    </thead>
+    <tbody>
 
-    {% for label, content in rows %}
-      {% if content %}
-      <tr>
-        <td style="width: 30%"><b>{{label}}</b></td>
-        <td>{{content}}</td>
-      </tr>
-      {% endif %}
-    {% endfor %}
+      {% for label, content in rows %}
+        {% if content %}
+        <tr>
+          <td style="width: 30%"><b>{{label}}</b></td>
+          <td>{{content}}</td>
+        </tr>
+        {% endif %}
+      {% endfor %}
 
-  </tbody>
-  </table>
+    </tbody>
+    </table>
+  </div>
 
   <a class="btn btn-warning float-right" href="{% url 'studies-deactivate' study.id %}">Delete study</a>
   <a class="btn btn-link float-right" href="{% url 'studies-list' %}">Back to study list</a>

--- a/surveys/templates/study_list.html
+++ b/surveys/templates/study_list.html
@@ -24,28 +24,30 @@ time and space, and can contain multiple related surveys.
 {% endblock %}
 
 {% block card_content %}
-  <table id="studies-list" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Title</th>
-      <th scope="col">Agency</th>
-      <th scope="col">Manager</th>
-      <th scope="col">Manager Email</th>
-      <th class="text-center" scope="col">Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for study in studies %}
+  <div class="table-responsive">
+    <table id="studies-list" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td><b><a href="{% url 'studies-detail' study.id %}">{{study.title}}</a></b></td>
-        <td>{{study.agency}}</td>
-        <td>{{study.manager_name}}</td>
-        <td>{{study.manager_email}}</td>
-        <td class="text-center"><a href="{% url 'studies-deactivate' study.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        <th scope="col">Title</th>
+        <th scope="col">Agency</th>
+        <th scope="col">Manager</th>
+        <th scope="col">Manager Email</th>
+        <th class="text-center" scope="col">Delete</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for study in studies %}
+        <tr>
+          <td><b><a href="{% url 'studies-detail' study.id %}">{{study.title}}</a></b></td>
+          <td>{{study.agency}}</td>
+          <td>{{study.manager_name}}</td>
+          <td>{{study.manager_email}}</td>
+          <td class="text-center"><a href="{% url 'studies-deactivate' study.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/survey_list_edit.html
+++ b/surveys/templates/survey_list_edit.html
@@ -22,32 +22,34 @@ When a survey is ready to be run it can be published, at which point it can no l
 {% endblock %}
 
 {% block card_content %}
-  <table id="survey-list-edit" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Survey Name</th>
-      <th scope="col">Last Updated</th>
-      <th scope="col">Type</th>
-      <th class="text-center" scope="col">Edit</th>
-      <th class="text-center" scope="col">Preview</th>
-      <th class="text-center" scope="col">Publish</th>
-      <th class="text-center" scope="col">Delete</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for survey in surveys %}
+  <div class="table-responsive">
+    <table id="survey-list-edit" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td><b>{{survey.name}}</b></td>
-        <td>{{survey.updated}}</td>
-        <td>{{survey.type | title}}</td>
-        <td class="text-center"><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>
-        <td class="text-center"><a href="{% url 'fobi.view_form_entry' survey.slug %}"><i class="fas fa-eye icon preview"></i></a></td>
-        <td class="text-center"><a href="{% url 'surveys-publish' survey.id %}"><i class="far fa-newspaper icon publish"></i></a></td>
-        <td class="text-center"><a href="{% url 'surveys-deactivate' survey.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        <th scope="col">Survey Name</th>
+        <th scope="col">Last Updated</th>
+        <th scope="col">Type</th>
+        <th class="text-center" scope="col">Edit</th>
+        <th class="text-center" scope="col">Preview</th>
+        <th class="text-center" scope="col">Publish</th>
+        <th class="text-center" scope="col">Delete</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for survey in surveys %}
+        <tr>
+          <td><b>{{survey.name}}</b></td>
+          <td>{{survey.updated}}</td>
+          <td>{{survey.type | title}}</td>
+          <td class="text-center"><a href="{% url 'fobi.edit_form_entry' survey.id %}"><i class="fas fa-pencil-alt icon edit"></i></a></td>
+          <td class="text-center"><a href="{% url 'fobi.view_form_entry' survey.slug %}"><i class="fas fa-eye icon preview"></i></a></td>
+          <td class="text-center"><a href="{% url 'surveys-publish' survey.id %}"><i class="far fa-newspaper icon publish"></i></a></td>
+          <td class="text-center"><a href="{% url 'surveys-deactivate' survey.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/survey_list_run.html
+++ b/surveys/templates/survey_list_run.html
@@ -19,38 +19,40 @@
 {% endblock %}
 
 {% block card_content %}
-  <table id="survey-list-run" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Survey Name</th>
-      <th scope="col">Type</th>
-      <th scope="col">Length</th>
-      <th scope="col">Last Run</th>
-      <th class="text-center" scope="col">Run</th>
-      {% if user.is_staff %}
-        <th class="text-center" scope="col">Delete</th>
-      {% endif %}
-    </tr>
-  </thead>
-  <tbody>
-    {% for survey in surveys %}
+  <div class="table-responsive">
+    <table id="survey-list-run" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td><b>{{survey.name}}</b></td>
-        <td>{{survey.type}}</td>
-        {% if survey.question_count == 1 %}
-          <td>{{survey.question_count}} question</td>
-        {% else %}
-          <td>{{survey.question_count}} questions</td>
-        {% endif %}
-        <td>{{survey.last_run}}</td>
-        <td class="text-center"><a class="btn btn-primary mt-0" href="{% url 'fobi.view_form_entry' survey.slug %}">Run survey</a></td>
+        <th scope="col">Survey Name</th>
+        <th scope="col">Type</th>
+        <th scope="col">Length</th>
+        <th scope="col">Last Run</th>
+        <th class="text-center" scope="col">Run</th>
         {% if user.is_staff %}
-          <td class="text-center"><a href="{% url 'surveys-deactivate' survey.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+          <th class="text-center" scope="col">Delete</th>
         {% endif %}
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for survey in surveys %}
+        <tr>
+          <td><b>{{survey.name}}</b></td>
+          <td>{{survey.type}}</td>
+          {% if survey.question_count == 1 %}
+            <td>{{survey.question_count}} question</td>
+          {% else %}
+            <td>{{survey.question_count}} questions</td>
+          {% endif %}
+          <td>{{survey.last_run}}</td>
+          <td class="text-center"><a class="btn btn-primary mt-0" href="{% url 'fobi.view_form_entry' survey.slug %}">Run survey</a></td>
+          {% if user.is_staff %}
+            <td class="text-center"><a href="{% url 'surveys-deactivate' survey.id %}"><i class="fas fa-times-circle icon deactivate"></i></a></td>
+          {% endif %}
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}

--- a/surveys/templates/survey_submitted_detail.html
+++ b/surveys/templates/survey_submitted_detail.html
@@ -48,26 +48,28 @@ Use this page to download, view, and construct analyses of your collected survey
     <h4 class="card-title">Export</h5>
     <br />
 
-    <table class="table table-hover table-striped table-bordered table-responsive display nowrap" id="survey-submitted-detail">
-    <thead>
-      <tr>
-        <th scope="col">Time Submitted</th>
-        {% for question in questions %}
-          <th scope="col">{{question}}</th>
-        {% endfor %}
-      </tr>
-    </thead>
-    <tbody>
-      {% for survey in surveys_submitted %}
+    <div class="table-responsive">
+      <table class="table table-hover table-striped table-bordered display nowrap" id="survey-submitted-detail">
+      <thead>
         <tr>
-          <td>{{survey.time_stop}}</td>
-          {% for component in survey.components %}
-            <td>{{component.saved_data}}</td>
+          <th scope="col">Time Submitted</th>
+          {% for question in questions %}
+            <th scope="col">{{question}}</th>
           {% endfor %}
         </tr>
-      {% endfor %}
-    </tbody>
-    </table>
+      </thead>
+      <tbody>
+        {% for survey in surveys_submitted %}
+          <tr>
+            <td>{{survey.time_stop}}</td>
+            {% for component in survey.components %}
+              <td>{{component.saved_data}}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+      </table>
+    </div>
 
     <br />
     <h4 class="card-title">Analyze</h5>

--- a/surveys/templates/survey_submitted_list.html
+++ b/surveys/templates/survey_submitted_list.html
@@ -21,32 +21,34 @@ An overview of collected survey data.
 {% endblock %}
 
 {% block card_content %}
-  <table id="submitted-survey-list" class="table table-hover table-striped table-responsive-sm card-text">
-  <thead>
-    <tr>
-      <th scope="col">Survey Title</th>
-      <th scope="col">Times Run</th>
-      <th scope="col">Last Submitted</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for survey in surveys_submitted %}
+  <div class="table-responsive">
+    <table id="submitted-survey-list" class="table table-hover table-striped card-text">
+    <thead>
       <tr>
-        <td>
-          {% if survey.form_title != '[Deleted Survey]' %}
-            <a href="{% url 'surveys-submitted-detail' survey.form_id %}">
-              {{survey.form_title}}
-            </a>
-          {% else %}
-              {{survey.form_title}}
-          {% endif %}
-        </td>
-        <td>{{survey.times_run}} submissions</td>
-        <td>{{survey.time_stop}}</td>
+        <th scope="col">Survey Title</th>
+        <th scope="col">Times Run</th>
+        <th scope="col">Last Submitted</th>
       </tr>
-    {% endfor %}
-  </tbody>
-  </table>
+    </thead>
+    <tbody>
+      {% for survey in surveys_submitted %}
+        <tr>
+          <td>
+            {% if survey.form_title != '[Deleted Survey]' %}
+              <a href="{% url 'surveys-submitted-detail' survey.form_id %}">
+                {{survey.form_title}}
+              </a>
+            {% else %}
+                {{survey.form_title}}
+            {% endif %}
+          </td>
+          <td>{{survey.times_run}} submissions</td>
+          <td>{{survey.time_stop}}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
 {% endblock %}
 
 {% block footer_js %}


### PR DESCRIPTION
## Overview

Closes #202. This is a bug fix with how I'd previously been employing the Bootstrap `table-responsive` class. It's now on the outer `div` as it belongs, not on the `table` itself!


## Testing Instructions

 * Run the site locally, log in as a superuser, and look at the list views for: `Agency`, `Study`, `Location`, `Census Areas`, `Survey Edit`, `Survey Run`, `Submitted Survey`, `Submitted Survey Detail`
