### PR TITLE
Hard coded template surveys

### DIFF
--- a/fobi_custom/plugins/form_elements/fields/intercept/age_intercept/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/age_intercept/forms.py
@@ -12,7 +12,6 @@ class AgeInterceptForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "How old are you?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", ""),
     ]

--- a/fobi_custom/plugins/form_elements/fields/intercept/household_tenure/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/household_tenure/forms.py
@@ -12,7 +12,6 @@ class HouseholdTenureForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What year did you move into your current address?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", False),
     ]

--- a/fobi_custom/plugins/form_elements/fields/intercept/location_intersection_home/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/location_intersection_home/forms.py
@@ -12,7 +12,6 @@ class LocationIntersectionHomeForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What is the closest intersection to your home?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", ""),
     ]

--- a/fobi_custom/plugins/form_elements/fields/intercept/location_intersection_work/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/location_intersection_work/forms.py
@@ -12,7 +12,6 @@ class LocationIntersectionWorkForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What is the closest intersection to your workplace?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", ""),
     ]

--- a/fobi_custom/plugins/form_elements/fields/intercept/location_zip_home/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/location_zip_home/forms.py
@@ -12,7 +12,6 @@ class LocationZipHomeForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What is the zip code of your home?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", ""),
     ]

--- a/fobi_custom/plugins/form_elements/fields/intercept/location_zip_work/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/intercept/location_zip_work/forms.py
@@ -12,7 +12,6 @@ class LocationZipWorkForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What is the zip code of your workplace?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", ""),
     ]

--- a/fobi_custom/plugins/form_elements/fields/metadata/total/forms.py
+++ b/fobi_custom/plugins/form_elements/fields/metadata/total/forms.py
@@ -12,7 +12,6 @@ class TotalForm(forms.Form, BaseFormFieldPluginForm):
     plugin_data_fields = [
         ("label", "What is the total number of people counted in this survey?"),
         ("name", "name"),
-        ("age", ""),
         ("help_text", ""),
         ("required", True),
     ]

--- a/surveys/models.py
+++ b/surveys/models.py
@@ -50,7 +50,7 @@ class SurveyFormEntry(FormEntry):
     active = models.BooleanField(default=True)
 
     def __str__(self):
-        return self.name + " (" + str(self.type) + ")"
+        return self.name
 
 
 class CensusBlockGroup(models.Model):

--- a/surveys/survey_template_data/survey_templates.json
+++ b/surveys/survey_template_data/survey_templates.json
@@ -1,23 +1,165 @@
 [
   {
-    "name": "Sample Survey Template Intercept",
-    "type": "intercept",
+    "name": "Event Survey – Observational",
+    "type": "observational",
     "questions": [
       {
-        "plugin_data": "{\"label\": \"What year did you move into your current address?\", \"age\": null, \"help_text\": \"\", \"required\": false}",
-        "plugin_uid": "household_tenure",
+        "plugin_data": "{\"label\": \"How many people do you see in each age range?\", \"detail_level\": \"basic\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "age_observational",
         "position": 1
+      },
+      {
+        "plugin_data": "{\"label\": \"How many people do you see of each gender?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "gender_observational",
+        "position": 2
+      },
+      {
+        "plugin_data": "{\"label\": \"How many people do you see engaged in each activity?\", \"detail_level\": \"basic\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "activity_observational",
+        "position": 3
+      },
+      {
+        "plugin_data": "{\"label\": \"How many people do you see in each size group?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "groups_observational",
+        "position": 4
       }
     ]
   },
   {
-    "name": "Sample Survey Template Observational",
+    "name": "Event Survey – Intercept",
+    "type": "intercept",
+    "questions": [
+      {
+        "plugin_data": "{\"label\": \"How did you hear about this event?\", \"choices\": \"Facebook\\r\\nTwitter\\r\\nInstagram\\r\\nEmail\\r\\nPosters/signs\\r\\nFriend/word of mouth\\r\\nOther\", \"help_text\": \"\", \"initial\": \"\", \"required\": false}",
+        "plugin_uid": "radio",
+        "position": 1
+      },
+      {
+        "plugin_data": "{\"label\": \"On a scale from 1-5 (5 being the best), how would you rate this event?\", \"choices\": \"1\\r\\n2\\r\\n3\\r\\n4\\r\\n5\", \"help_text\": \"\", \"initial\": \"\", \"required\": false}",
+        "plugin_uid": "radio",
+        "position": 2
+      },
+      {
+        "plugin_data": "{\"label\": \"Based on your best guess, approximately how much money do you plan on spending at this event?\", \"help_text\": \"\", \"initial\": null, \"min_value\": null, \"max_value\": null, \"required\": false}",
+        "plugin_uid": "float",
+        "position": 3
+      },
+      {
+        "plugin_data": "{\"label\": \"What is the zip code of your home?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "location_zip_home",
+        "position": 4
+      },
+      {
+        "plugin_data": "{\"label\": \"What is the zip code of your workplace?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "location_zip_work",
+        "position": 5
+      },
+      {
+        "plugin_data": "{\"label\": \"What year did you move into your current address?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "household_tenure",
+        "position": 6
+      },
+      {
+        "plugin_data": "{\"label\": \"Which race or ethnicity best describes you?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "race",
+        "position": 7
+      },
+      {
+        "plugin_data": "{\"label\": \"How old are you?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "age_intercept",
+        "position": 8
+      },
+      {
+        "plugin_data": "{\"label\": \"What gender do you most identify with?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "gender_intercept",
+        "position": 9
+      },
+      {
+        "plugin_data": "{\"label\": \"What income group does your household fall under?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "income",
+        "position": 10
+      },
+      {
+        "plugin_data": "{\"label\": \"Any comments?\", \"help_text\": \"\", \"initial\": \"\", \"required\": false, \"max_length\": null, \"placeholder\": \"\"}",
+        "plugin_uid": "textarea",
+        "position": 11
+      }
+    ]
+  },
+  {
+    "name": "Park/Public Space Survey – Observational",
     "type": "observational",
     "questions": [
       {
+        "plugin_data": "{\"label\": \"How many people do you see in each age range?\", \"detail_level\": \"basic\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "age_observational",
+        "position": 1
+      },
+      {
         "plugin_data": "{\"label\": \"How many people do you see of each gender?\", \"help_text\": \"\", \"required\": false}",
         "plugin_uid": "gender_observational",
+        "position": 2
+      },
+      {
+        "plugin_data": "{\"label\": \"How many people do you see engaged in each activity?\", \"detail_level\": \"basic\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "activity_observational",
+        "position": 3
+      },
+      {
+        "plugin_data": "{\"label\": \"How many people do you see in each size group?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "groups_observational",
+        "position": 4
+      }
+    ]
+  },
+  {
+    "name": "Park/Public Space Survey – Intercept",
+    "type": "intercept",
+    "questions": [
+      {
+        "plugin_data": "{\"label\": \"What is the zip code of your home?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "location_zip_home",
         "position": 1
+      },
+      {
+        "plugin_data": "{\"label\": \"What is the zip code of your workplace?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "location_zip_work",
+        "position": 2
+      },
+      {
+        "plugin_data": "{\"label\": \"What year did you move into your current address?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "household_tenure",
+        "position": 3
+      },
+      {
+        "plugin_data": "{\"label\": \"Which race or ethnicity best describes you?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "race",
+        "position": 4
+      },
+      {
+        "plugin_data": "{\"label\": \"How old are you?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "age_intercept",
+        "position": 5
+      },
+      {
+        "plugin_data": "{\"label\": \"What gender do you most identify with?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "gender_intercept",
+        "position": 6
+      },
+      {
+        "plugin_data": "{\"label\": \"What income group does your household fall under?\", \"help_text\": \"\", \"required\": false}",
+        "plugin_uid": "income",
+        "position": 7
+      },
+      {
+        "plugin_data": "{\"label\": \"How often do you visit this park/public space?\", \"choices\": \"I have never visited this space\\r\\nA few times per year\\r\\nMonthly\\r\\nWeekly\\r\\nMultiple times per week\", \"help_text\": \"\", \"initial\": \"\", \"required\": false}",
+        "plugin_uid": "radio",
+        "position": 8
+      },
+      {
+        "plugin_data": "{\"label\": \"Any comments?\", \"help_text\": \"\", \"initial\": \"\", \"required\": false, \"max_length\": null, \"placeholder\": \"\"}",
+        "plugin_uid": "textarea",
+        "position": 9
       }
     ]
   }

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -405,7 +405,7 @@ class SurveyListEdit(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['surveys'] = context['surveys'].exclude(active=False).filter(published=False).order_by('-updated')
+        context['surveys'] = context['surveys'].filter(active=True, is_cloneable=False, published=False).order_by('-updated')
         context['published'] = False
 
         return context
@@ -418,7 +418,7 @@ class SurveyListRun(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['surveys'] = context['surveys'].exclude(active=False).filter(published=True).order_by('-updated')
+        context['surveys'] = context['surveys'].filter(active=True, is_cloneable=False, published=True).order_by('-updated')
         context['published'] = True
 
         for survey in context['surveys']:

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -2,7 +2,7 @@ import json
 import uuid
 
 from django.views.generic import TemplateView, ListView, UpdateView, DetailView
-from django.views.generic.edit import CreateView, FormView
+from django.views.generic.edit import CreateView
 
 from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect, JsonResponse
@@ -11,9 +11,6 @@ from django.forms import modelformset_factory
 from django.contrib import messages
 
 from pldp import models as pldp_models
-
-from users.models import JustSpacesUser
-from users.admin import JustSpacesUserCreationForm
 
 from fobi.views import add_form_handler_entry
 from fobi import models as fobi_models
@@ -343,7 +340,6 @@ class SurveyCreate(CreateView):
             form_entry_id=form_entry_id,
         )
 
-
     def get_success_url(self):
         form_entry_id = self.object.formentry_ptr_id
         success_url = reverse_lazy('fobi.edit_form_entry', kwargs={'form_entry_id': form_entry_id})
@@ -405,7 +401,10 @@ class SurveyListEdit(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['surveys'] = context['surveys'].filter(active=True, is_cloneable=False, published=False).order_by('-updated')
+        context['surveys'] = context['surveys'].filter(active=True,
+                                                       is_cloneable=False,
+                                                       published=False
+                                                       ).order_by('-updated')
         context['published'] = False
 
         return context
@@ -418,7 +417,10 @@ class SurveyListRun(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['surveys'] = context['surveys'].filter(active=True, is_cloneable=False, published=True).order_by('-updated')
+        context['surveys'] = context['surveys'].filter(active=True,
+                                                       is_cloneable=False,
+                                                       published=True
+                                                       ).order_by('-updated')
         context['published'] = True
 
         for survey in context['surveys']:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -104,17 +104,17 @@ def test_survey_form(client, user_staff, study, location):
                             )
 
     with open(filepath) as json_file:
-        first_template_json = json.load(json_file)[0]
+        first_template_json = json.load(json_file)[1]  # test with an intercept template
         template_name = first_template_json['name']
-        template = SurveyFormEntry.objects.get(name=template_name).formentry_ptr_id
+        template = SurveyFormEntry.objects.get(name=template_name)
 
         form_data = {
             'user': get_response.context['form']['user'].value(),
             'name': 'Test Survey',
             'study': study.id,
             'location': location.id,
-            'type': get_response.context['form']['type'].value(),
-            'survey_template': template
+            'type': get_response.context['form']['type'].value(),  # intercept should be the default value
+            'survey_template': template.id
         }
 
         post_response = client.post(url, form_data)


### PR DESCRIPTION
## Overview

Closes #195. This PR hard codes templated surveys as described by Tyler here: https://docs.google.com/document/d/1WGEWdb3OGAGZfvunCiUNmrO7NanYhDBPe14lT1931DE/edit

I put together the JSON template file manually, but this could/should be automated in the future if this project is extended! I'll leave couple notes in-line on changes as well. 

We'll need to add the `race_observational` question to these templates once it's created, which I've noted in #203.

## Testing Instructions

 * Import templates: `python manage.py import_survey_templates`
* Create a new survey with each survey template. Make sure that if they types don't match the form is invalid.
* Make sure you can edit templated survey questions
