### PR TITLE
Add table of contents

### DIFF
--- a/surveys/templates/about.html
+++ b/surveys/templates/about.html
@@ -7,6 +7,19 @@ Welcome to <b><i>Just Spaces</b></i>
 {% endblock %}
 
 {% block card_content %}
+<div>
+  <ul style="list-style-type:circle;">
+    <li><a href="#ucd-organizational-background">UCD Organizational Background</a></li>
+    <li><a href="#just-spaces-project-background"><i><b>Just Spaces</b></i> Project Background</a></li>
+    <li><a href="#just-spaces-tool">The <b><i>Just Spaces</b></i> Tool</a></li>
+    <li><a href="#beyond-the-tool"><b><i>Just Spaces</b></i> Beyond the Tool</a></li>
+    <li><a href="#using-the-tool">Using the Tool</a></li>
+    <li><a href="#faq">Frequently Asked Questions</a></li>
+  </ul>
+</div>
+
+<hr>
+
 <img class="img-fluid d-block rounded mb-4" src="{% static 'images/porch.jpg' %}" />
 
 <p>The <b><i>Just Spaces</i> data tool</b> is a project of
@@ -17,7 +30,9 @@ in its own public spaces, events, and Green City Works landscaping social
 enterprise, and to develop a mobile-ready data collection and analysis tool
 with our partners at <a href="https://datamade.us/"><b>DataMade</b></a>.</p>
 
-<h4>UCD Organizational Background</h4>
+<hr>
+
+<h4 id="ucd-organizational-background">UCD Organizational Background</h4>
 
 <p>University City District is a partnership of world renowned anchor
 institutions, small businesses and residents that creates opportunity, and
@@ -40,7 +55,9 @@ these spaces.  UCD also regularly engages with public spaces that are not
 directly under our control, including public parks and privately owned,
 publicly accessible plazas and parks.</p>
 
-<h4><i><b>Just Spaces</b></i> Project Background</h4>
+<hr>
+
+<h4 id="just-spaces-project-background"><i><b>Just Spaces</b></i> Project Background</h4>
 
 <p><b><i>Just Spaces</b></i> is UCD’s effort to seize the imperative as a developer and
 operator of public spaces to engage in principled, frank analysis of our work
@@ -82,7 +99,9 @@ inflame existing injustices. Most owners and operators of public space networks
 tend to focus heavily on the design of individual spaces; our work aims to
 change this paradigm by prioritizing justice.</p>
 
-<h4>The <b><i>Just Spaces</b></i> Tool</h4>
+<hr>
+
+<h4 id="just-spaces-tool">The <b><i>Just Spaces</b></i> Tool</h4>
 
 
 <p>The <b><i>Just Spaces</b></i> project has created a mobile web-based tool to
@@ -123,7 +142,9 @@ not use our spaces?</p>
 
 <img class="img-fluid d-block rounded mb-4" src="{% static 'images/parklets.jpg' %}" />
 
-<h4><b><i>Just Spaces</b></i> Beyond the Tool</h4>
+<hr>
+
+<h4 id="beyond-the-tool"><b><i>Just Spaces</b></i> Beyond the Tool</h4>
 
 <p>For UCD the <b><i>Just Spaces</b></i> endeavor has been about much more than technology.
 It has been an opportunity to take stock of our work, convene stakeholders,
@@ -148,7 +169,9 @@ the American Society of Landscape Architects,
 <a href="https://www.trafficandtransit.com/equitable-just-and-inclusive-transportation-systems-are-within-our-reach">publication in Traffic and Transit</a>,
 and an event in collaboration with <a href="http://www.urbanconsulate.com/events/2019/4/16/just-spaces">Urban Consulate</a>.</p>
 
-<h4>Using the Tool</h4>
+<hr>
+
+<h4 id="using-the-tool">Using the Tool</h4>
 
 <p>To use the Just Spaces tool, please fill out
 <a href="https://docs.google.com/forms/d/e/1FAIpQLSf4IV4i30VBI6y8ZfdLmvm9065Wd8MY8lrZbvk2ZG6irC8dxw/viewform">this short form</a>.
@@ -229,7 +252,9 @@ customizable to fit your needs.</p>
 
 <img class="img-fluid d-block rounded mb-4" src="{% static 'images/trolley-portal.jpg' %}" />
 
-<h4>Frequently Asked Questions</h4>
+<hr>
+
+<h4 id="faq">Frequently Asked Questions</h4>
 
 <ol>
   <li>


### PR DESCRIPTION
## Overview

Closes #210. This PR adds a table of contents to the top of the About page and id tags to all the headers. It should look like this: 

![Screen Shot 2019-07-30 at 9 45 58 AM](https://user-images.githubusercontent.com/1094243/62139380-dc349d00-b2ae-11e9-8802-4cb07193ee53.png)

## Testing Instructions

* Run the site locally and navigate to the homepage. Make sure it looks like the above screenshot.
* Click some links!
