### PR TITLE
Persist subdomain redirect for production hostname

### DIFF
--- a/configs/just-spaces-production.conf.nginx
+++ b/configs/just-spaces-production.conf.nginx
@@ -72,7 +72,7 @@ server {
 }
 server {
     listen 80;
-    server_name {{ domain }};
+    server_name {{ domain }} www.{{ domain}};
 
     location / {
         return 301 https://{{ domain }}$request_uri;


### PR DESCRIPTION
## Overview

Previously, we neglected to set up `www` subdomain redirects for the production site. Persist these redirects in the production config.

Connects https://github.com/datamade/devops/issues/112.

## Testing Instructions

* Shell into the production server, tail the Nginx conf for the site, and confirm that the line I changed in this PR is also changed on the server
 * Visit www.justspacesproject.org and confirm you get redirected to the root domain