### PR TITLE
Social Metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   postgresql: '9.6'
   apt:
     packages:
-    - postgresql-9.6-postgis-2.3
+    - postgresql-9.6-postgis-2.4
 before_script:
 - psql -c 'create database "just-spaces";' -U postgres
 - psql -U postgres -d travis -c "create extension postgis"

--- a/justspaces/settings.py
+++ b/justspaces/settings.py
@@ -199,3 +199,10 @@ LEAFLET_CONFIG = {
         ),
     ]
 }
+
+SITE_META = {
+    'site_name' : 'Just Spaces',
+    'site_desc' : 'A data tool from University City District to ensure that public spaces are deeply inclusive and just.',
+    'site_author' : 'University City District',
+    'site_url' : 'https://justspacesproject.org/',
+}

--- a/justspaces/settings.py
+++ b/justspaces/settings.py
@@ -199,10 +199,3 @@ LEAFLET_CONFIG = {
         ),
     ]
 }
-
-SITE_META = {
-    'site_name' : 'Just Spaces',
-    'site_desc' : 'A data tool from University City District to ensure that public spaces are deeply inclusive and just.',
-    'site_author' : 'University City District',
-    'site_url' : 'https://justspacesproject.org/',
-}

--- a/surveys/templates/base.html
+++ b/surveys/templates/base.html
@@ -3,9 +3,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="{% static 'images/favicon.png' %}">
+
+    {% include 'partials/seo.html' %}
 
     <!-- CSS -->
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
@@ -25,8 +24,6 @@
 
     {% block extrajs %}
     {% endblock %}
-
-    <title>Just Spaces</title>
   </head>
 
   <body>

--- a/surveys/templates/partials/seo.html
+++ b/surveys/templates/partials/seo.html
@@ -1,0 +1,25 @@
+{% load staticfiles %}
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<link rel="icon" href="{% static 'images/favicon.png' %}">
+
+<title>Just Spaces</title>
+
+<meta name="description" content="A data tool from University City District to ensure that public spaces are deeply inclusive and just.">
+<meta name="author" content="University City District}">
+
+<!-- Facebook -->
+<meta property="og:site_name" content="Just Spaces">
+<meta property="og:title" content="Just Spaces">
+<meta property="og:type" content="website">
+<meta property="og:description" content="A data tool from University City District to ensure that public spaces are deeply inclusive and just.">
+<meta property="og:url" content="https://justspacesproject.org/">
+<meta property="og:image" content="https://justspacesproject.org/{% static 'images/porch.jpg' %}">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:description" content="A data tool from University City District to ensure that public spaces are deeply inclusive and just.">
+<meta name="twitter:title" content="Just Spaces">
+<meta name="twitter:url" content="https://justspacesproject.org/">
+<meta name="twitter:image:src" content="https://justspacesproject.org/{% static 'images/porch.jpg' %}">


### PR DESCRIPTION
## Overview

Closes #216. This PR adds metadata for Twitter and Facebook cards. Once this is on staging we should check it against [this](https://cards-dev.twitter.com/validator) Twitter validator and [this](https://developers.facebook.com/tools/debug/) Facebook one. Unless you know of a way to test locally, @jeancochrane?

For reasons that I believe are unrelated to the changes made in this PR, Travis at first threw this error:

```
ERROR:  could not access file "$libdir/postgis-2.4": No such file or directory
The command "psql -U postgres -d travis -c "create extension postgis"" failed and exited with 1 during
```

Fixed by updating the `postgresql-9.6-postgis-2.3` package to `postgresql-9.6-postgis-2.4`!