### PR TITLE
Add new regions to data import

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -55,3 +55,13 @@ docker-compose run --rm make clean
 Next, adjust the global variable `YEAR` in `Makefile` to correspond to the year you'd like to retrieve ACS estimates for.
 
 Finally, rerun the pipeline with `docker-compose run --rm make`. This will create new files in the `data` directory that you can use to import into the app.
+
+## Adding a new Region
+
+If you'd like to add a new CensusRegion, here are the steps you should follow:
+
+1. Update `STATES` in `scripts/states.py`
+    1. If the region is in a new state, create a new entry in `STATES` for that state; otherwise, update the existing state
+    2. Add a region to the `regions` dictionary with the counties comprising this region, its default map zoom level, and its center coordinate
+2. Add any new states to the `shapefiles` target in `shapefiles.mk`
+3. Rerun the data import with `docker-compose run --rm make clean` and `docker-compose run --rm make`

--- a/data/scripts/states.py
+++ b/data/scripts/states.py
@@ -5,14 +5,22 @@ US = '1'
 # Region centroids are found by searching "${city} coordinates" for the primary
 # city in each region. Zoom levels are configurable as a separate parameter for
 # cases where the region is too large to fit the default zoom level, 11.
+# Even though regions can span multiple states, each instance of the 'region'
+# dictionary should have its own centroid and default_zoom -- this is necessary
+# in order to support Python <3.6, where dictionaries are unordered by default.
 STATES = {
-    '42': {
-        'name': 'Pennsylvania',
+    '42': {  # The FIPS code of the state
+        'name': 'Pennsylvania',  # The name of the state
         'regions': {
-            'Philadelphia': {
-                'counties': ['101'],
+            'Philadelphia': {  # The name of the region
+                'counties': ['101'],  # FIPS codes for counties comprising this reigon
+                'default_zoom': 11,  # Default map zoom level for this region
+                'centroid': (40, -75.16),  # Coordinate center point of this region
+            },
+            'New York City': {
+                'counties': ['103'],
                 'default_zoom': 11,
-                'centroid': (40, -75.16),
+                'centroid': (40.71, -74.00),
             },
         },
     },
@@ -36,6 +44,11 @@ STATES = {
                              '231', '247', '255', '297'],
                 'default_zoom': 11,
                 'centroid': (33.75, -84.39),
+            },
+            'Macon, GA': {
+                'counties': ['021', '079', '169', '207', '289'],
+                'default_zoom': 11,
+                'centroid': (32.84, -83.63),
             },
         },
     },
@@ -98,6 +111,11 @@ STATES = {
                 'default_zoom': 11,
                 'centroid': (41.88, -87.63),
             },
+            'Louisville, KY': {
+                'counties': ['019', '043', '061', '175'],
+                'default_zoom': 11,
+                'centroid': (38.25, -85.76),
+            },
         },
     },
     '55': {
@@ -107,6 +125,190 @@ STATES = {
                 'counties': ['059'],
                 'default_zoom': 11,
                 'centroid': (41.88, -87.63),
+            },
+            'Minneapolis-Saint Paul': {
+                'counties': ['093', '109'],
+                'default_zoom': 11,
+                'centroid': (44.94, -93.20),
+            },
+        },
+    },
+    '48': {
+        'name': 'Texas',
+        'regions': {
+            'Dallas-Fort Worth': {
+                'counties': ['085', '113', '119', '121', '139', '231',
+                             '251', '257', '367', '397', '439', '497'],
+                'default_zoom': 11,
+                'centroid': (32.71, -96.92),
+            },
+            'Houston': {
+                'counties': ['015', '039', '071', '157', '167', '201', '291',
+                             '339', '407', '473'],
+                'default_zoom': 11,
+                'centroid': (29.76, -95.37),
+            },
+        },
+    },
+    '26': {
+        'name': 'Michigan',
+        'regions': {
+            'Detroit': {
+                'counties': ['087', '093', '099', '125', '147', '163'],
+                'default_zoom': 11,
+                'centroid': (42.33, -83.05),
+            },
+            'Lansing, MI': {
+                'counties': ['037', '045', '065'],
+                'default_zoom': 11,
+                'centroid': (42.73, -84.56),
+            },
+        },
+    },
+    '29': {
+        'name': 'Missouri',
+        'regions': {
+            'Kansas City': {
+                'counties': ['013', '025', '037', '047', '049', '095', '107',
+                             '165', '177'],
+                'default_zoom': 11,
+                'centroid': (39.01, -94.58),
+            },
+        },
+    },
+    '20': {
+        'name': 'Kansas',
+        'regions': {
+            'Kansas City': {
+                'counties': ['059', '091', '103', '107', '121', '209'],
+                'default_zoom': 11,
+                'centroid': (39.01, -94.58),
+            },
+        },
+    },
+    '06': {
+        'name': 'California',
+        'regions': {
+            'Los Angeles': {
+                'counties': ['037', '059'],
+                'default_zoom': 11,
+                'centroid': (34.05, -118.24),
+            },
+            'San Francisco': {
+                'counties': ['001', '013', '041', '075', '081'],
+                'default_zoom': 11,
+                'centroid': (37.83, -122.29),
+            },
+            'San Jose': {
+                'counties': ['069', '085'],
+                'default_zoom': 11,
+                'centroid': (37.34, -121.89),
+            },
+        },
+    },
+    '21': {
+        'name': 'Kentucky',
+        'regions': {
+            'Louisville, KY': {
+                'counties': ['029', '103', '111', '163', '179', '185', '211',
+                             '215', '223'],
+                'default_zoom': 11,
+                'centroid': (38.25, -85.76),
+            },
+        },
+    },
+    '12': {
+        'name': 'Florida',
+        'regions': {
+            'Miami': {
+                'counties': ['011', '086', '099'],
+                'default_zoom': 11,
+                'centroid': (25.76, -80.19),
+            },
+        },
+    },
+    '27': {
+        'name': 'Minnesota',
+        'regions': {
+            'Minneapolis-Saint Paul': {
+                'counties': ['003', '019', '025', '037', '053', '059', '123',
+                             '139', '141', '163', '171'],
+                'default_zoom': 11,
+                'centroid': (44.94, -93.20),
+            },
+        },
+    },
+    '34': {
+        'name': 'New Jersey',
+        'regions': {
+            'New York City': {
+                'counties': ['003', '013', '017', '019', '023', '025', '027',
+                             '029', '031', '035', '037', '039'],
+                'default_zoom': 11,
+                'centroid': (40.71, -74.00),
+            },
+        },
+    },
+    '36': {
+        'name': 'New York',
+        'regions': {
+            'New York City': {
+                'counties': ['005', '047', '059', '061', '079', '081', '085',
+                             '087', '103', '119'],
+                'default_zoom': 11,
+                'centroid': (40.71, -74.00),
+            },
+        },
+    },
+    '53': {
+        'name': 'Washington',
+        'regions': {
+            'Seattle': {
+                'counties': ['033', '053', '061'],
+                'default_zoom': 11,
+                'centroid': (47.61, -122.33),
+            },
+        },
+    },
+    '11': {
+        'name': 'District of Columbia',
+        'regions': {
+            'Washington, DC': {
+                'counties': ['001'],
+                'default_zoom': 11,
+                'centroid': (38.91, -77.04),
+            },
+        },
+    },
+    '24': {
+        'name': 'Maryland',
+        'regions': {
+            'Washington, DC': {
+                'counties': ['009', '017', '021', '031', '033'],
+                'default_zoom': 11,
+                'centroid': (38.91, -77.04),
+            },
+        },
+    },
+    '51': {
+        'name': 'Virginia',
+        'regions': {
+            'Washington, DC': {
+                'counties': ['013', '043', '059', '061', '107', '153', '177',
+                             '179', '187', '510', '600', '610', '630', '683',
+                             '685'],
+                'default_zoom': 11,
+                'centroid': (38.91, -77.04),
+            },
+        },
+    },
+    '54': {
+        'name': 'West Virginia',
+        'regions': {
+            'Washington, DC': {
+                'counties': ['037'],
+                'default_zoom': 11,
+                'centroid': (38.91, -77.04),
             },
         },
     },

--- a/data/shapefiles.mk
+++ b/data/shapefiles.mk
@@ -8,7 +8,22 @@ shapefiles: final/shapefiles/cb_2018_42_bg_500k.shp \
             final/shapefiles/cb_2018_45_bg_500k.shp \
             final/shapefiles/cb_2018_17_bg_500k.shp \
             final/shapefiles/cb_2018_18_bg_500k.shp \
-            final/shapefiles/cb_2018_55_bg_500k.shp
+            final/shapefiles/cb_2018_55_bg_500k.shp \
+            final/shapefiles/cb_2018_48_bg_500k.shp \
+            final/shapefiles/cb_2018_26_bg_500k.shp \
+            final/shapefiles/cb_2018_29_bg_500k.shp \
+            final/shapefiles/cb_2018_20_bg_500k.shp \
+            final/shapefiles/cb_2018_06_bg_500k.shp \
+            final/shapefiles/cb_2018_21_bg_500k.shp \
+            final/shapefiles/cb_2018_12_bg_500k.shp \
+            final/shapefiles/cb_2018_27_bg_500k.shp \
+            final/shapefiles/cb_2018_34_bg_500k.shp \
+            final/shapefiles/cb_2018_36_bg_500k.shp \
+            final/shapefiles/cb_2018_53_bg_500k.shp \
+            final/shapefiles/cb_2018_11_bg_500k.shp \
+            final/shapefiles/cb_2018_24_bg_500k.shp \
+            final/shapefiles/cb_2018_51_bg_500k.shp \
+            final/shapefiles/cb_2018_54_bg_500k.shp
 
 raw/shapefiles/cb_2018_%_bg_500k.zip:
 	wget -O $@ https://www2.census.gov/geo/tiger/GENZ2018/shp/$(notdir $@)


### PR DESCRIPTION
## Overview

Add a few new regions to finalize the new geographic import pipeline drafted in #225.

In addition, add some documentation explaining how to do additional imports like this one in the future.
 
## Testing Instructions

### Redo the data import

There are only a few commands you need to run to redo the data import, but they can take a long time to complete. Get set up on something else while you wait.

* Change to the data directory: `cd data`
* Clean out old files: `docker-compose run --rm make clean`
* Create new source data: `docker-compose run --rm make` (this will take 20-30 minutes)
* Change back to the project directory: `cd ..`
* Import the new data `./manage.py import_data` (this will take 20-30 minutes)

### Test the new regions

* Run the development server: `./manage.py runserver`
* Log in and navigate to http://localhost:8000/census-areas/region/
* Use the region selector to load block groups for each region and confirm they look OK
    * Note: Two regions (New York and LA) contain so many block groups that the map widget feels slow on my machine. I'm going to raise this with Tyler and see how he wants to proceed -- I think an easy first step would be to restrict the block groups to NYC and LA instead of including the surrounding counties. If you notice any other regions that you think are unacceptably slow, let me know and I can raise those too.