### PR TITLE
Restrict DAD CensusArea choices by user's Agency

### DIFF
--- a/surveys/forms.py
+++ b/surveys/forms.py
@@ -318,7 +318,7 @@ class SurveyChartForm(forms.ModelForm):
         self.fields['primary_source'].widget.choices = source_choices
 
         # Restrict CensusAreas by the user's Agency
-        census_areas = survey_models.CensusArea.objects.all()
+        census_areas = survey_models.CensusArea.objects.filter(is_active=True)
         if user.agency is not None and not user.is_superuser:
             census_areas = census_areas.filter(
                 Q(agency=user.agency) | Q(agency__isnull=True)

--- a/surveys/forms.py
+++ b/surveys/forms.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from django import forms
-
+from django.db.models import Q
 from leaflet.forms.widgets import LeafletWidget
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
@@ -307,11 +307,21 @@ class SurveyChartForm(forms.ModelForm):
             'primary_source': forms.Select(),
         }
 
-    def __init__(self, *args, form_entry, **kwargs):
+    def __init__(self, *args, form_entry, user, **kwargs):
         self.form_entry = survey_models.SurveyFormEntry.objects.get(id=form_entry)
         super().__init__(*args, **kwargs)
+
         survey = pldp_models.Survey.objects.filter(form_id=form_entry)[0]
-        choices = [(component.name, component.label) for component in survey.components
-                   if component.type in fobi_types.ALL_VALID_TYPES]
-        choices = [('', '-----')] + choices  # Offer a null choice
-        self.fields['primary_source'].widget.choices = choices
+        source_choices = [(component.name, component.label) for component in survey.components
+                          if component.type in fobi_types.ALL_VALID_TYPES]
+        source_choices = [('', '-----')] + source_choices  # Offer a null choice
+        self.fields['primary_source'].widget.choices = source_choices
+
+        # Restrict CensusAreas by the user's Agency
+        census_areas = survey_models.CensusArea.objects.all()
+        if user.agency is not None and not user.is_superuser:
+            census_areas = census_areas.filter(
+                Q(agency=user.agency) | Q(agency__isnull=True)
+            )
+        census_area_choices = [(area.id, area.name) for area in census_areas]
+        self.fields['census_areas'].choices = census_area_choices

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -93,7 +93,7 @@ class AgencyRestrictQuerysetMixin(object):
         agency_kwargs = {agency_filter: self.request.user.agency}
         agency_null_kwargs = {agency_filter + '__isnull': True}
 
-        if self.request.user.agency is not None:
+        if not self.request.user.is_superuser and self.request.user.agency is not None:
             return queryset.filter(Q(**agency_kwargs) | Q(**agency_null_kwargs))
         else:
             return queryset

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -657,7 +657,10 @@ class SurveySubmittedDetail(TemplateView):
 
         context['chart_formset'] = self.ChartFormset(
             queryset=survey_models.SurveyChart.objects.filter(form_entry=context['form_entry']),
-            form_kwargs={'form_entry': context['form_entry_id']},
+            form_kwargs={
+                'form_entry': context['form_entry_id'],
+                'user': self.request.user
+            },
         )
 
         return context
@@ -666,7 +669,10 @@ class SurveySubmittedDetail(TemplateView):
         context = self.get_context_data(**kwargs)
         formset = self.ChartFormset(
             request.POST,
-            form_kwargs={'form_entry': kwargs['form_entry_id']}
+            form_kwargs={
+                'form_entry': kwargs['form_entry_id'],
+                'user': request.user
+            }
         )
         if formset.is_valid():
             for form in formset:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,6 +407,18 @@ def census_area(db, census_region):
 
 @pytest.fixture
 @pytest.mark.django_db
+def census_area_inactive(db, census_region):
+    return CensusArea.objects.create(
+        name='test inactive area',
+        is_active=False,
+        fips_codes=['1'],
+        region=census_region,
+        agency=None
+    )
+
+
+@pytest.fixture
+@pytest.mark.django_db
 def census_area_agency_1(db, agency, census_region):
     return CensusArea.objects.create(
         name='test area (Agency 1)',

--- a/tests/test_dad.py
+++ b/tests/test_dad.py
@@ -179,8 +179,8 @@ def test_valid_type_display(client, user_staff, survey, survey_form_entry, surve
 
 
 def test_census_area_option_restriction(client, user_staff, superuser,
-                                        survey_submitted_setup,
-                                        survey_form_entry, census_area,
+                                        survey_submitted_setup, survey_form_entry,
+                                        census_area, census_area_inactive,
                                         census_area_agency_1, census_area_agency_2):
     """Ensure that CensusArea options are restricted by the user's Agency."""
     client.force_login(user_staff)

--- a/tests/test_dad.py
+++ b/tests/test_dad.py
@@ -176,3 +176,34 @@ def test_valid_type_display(client, user_staff, survey, survey_form_entry, surve
         assert valid_component.name in get_response.content.decode('utf-8')
     for invalid_component in invalid_components:
         assert invalid_component.name not in get_response.content.decode('utf-8')
+
+
+def test_census_area_option_restriction(client, user_staff, superuser,
+                                        survey_submitted_setup,
+                                        survey_form_entry, census_area,
+                                        census_area_agency_1, census_area_agency_2):
+    """Ensure that CensusArea options are restricted by the user's Agency."""
+    client.force_login(user_staff)
+
+    get_url = reverse('surveys-submitted-detail',
+                      kwargs={'form_entry_id': survey_form_entry.id})
+    staff_response = client.get(get_url)
+    assert staff_response.status_code == 200
+
+    staff_formset = staff_response.context['chart_formset']
+    staff_choices = staff_formset.empty_form.fields['census_areas'].choices
+    staff_areas = [choice[1] for choice in staff_choices]
+    expected_staff_areas = [str(ca) for ca in (census_area, census_area_agency_1)]
+    assert set(staff_areas) == set(expected_staff_areas)
+
+    # Make sure superusers can see all CensusAreas
+    client.force_login(superuser)
+    superuser_response = client.get(get_url)
+    assert superuser_response.status_code == 200
+
+    superuser_formset = superuser_response.context['chart_formset']
+    superuser_choices = superuser_formset.empty_form.fields['census_areas'].choices
+    superuser_areas = [choice[1] for choice in superuser_choices]
+    expected_superuser_areas = [str(area) for area in
+                                (census_area, census_area_agency_1, census_area_agency_2)]
+    assert set(superuser_areas) == set(expected_superuser_areas)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -358,7 +358,7 @@ def test_census_area_create_params(client, user_staff, census_region):
 
 @pytest.mark.django_db
 def test_census_area_list(client, user_staff, census_area, census_area_agency_1,
-                          census_area_agency_2):
+                          census_area_agency_2, superuser):
     client.force_login(user_staff)
     url = reverse('census-areas-list')
     response = client.get(url)
@@ -370,8 +370,15 @@ def test_census_area_list(client, user_staff, census_area, census_area_agency_1,
 
     # Ensure that the only visible CensusAreas are A) those created by the agency
     # belonging to the user or B) those where CensusArea.agency is null
-    for area in census_areas:
-        assert area.name in [area.name for area in (census_area, census_area_agency_1)]
+    staff_areas = [census_area, census_area_agency_1]
+    assert set(census_areas) == set(staff_areas)
+
+    # Test that a superuser can see all CensusAreas
+    client.force_login(superuser)
+    superuser_response = client.get(url)
+    assert superuser_response.status_code == 200
+    superuser_areas = [census_area, census_area_agency_1, census_area_agency_2]
+    assert set(superuser_response.context['census_areas']) == set(superuser_areas)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

While finishing up the data import in #228, I noticed that SurveyChartForms were not properly restricting CensusAreas based on the user's Agency or `is_active` status. This PR fixes that small bug.

Closes #227. 

## Testing Instructions

* Make sure you have two Agencies with non-superuser staff members in each Agency
* Log in as one of your staff members and create a new CensusArea at http://localhost:8000/census-areas/region/
* Navigate to a submitted survey detail page at http://localhost:8000/surveys/submitted, load a chart, and confirm that the CensusArea you created is in the dropdown
* Log in as the staff member in the other Agency, navigate to a submitted survey detail page at http://localhost:8000/surveys/submitted, load a chart, and confirm that the CensusArea you created is **not** in the dropdown
* Log in as a superuser, navigate to a submitted survey detail page at http://localhost:8000/surveys/submitted, load a chart, and confirm that the CensusArea you created **is** in the dropdown
* As the superuser, navigate to http://localhost:8000/census-areas/ and delete the CensusArea you just created
* Navigate back to the submitted survey detail page and confirm that the CensusArea is no longer available in the chart selector dropdown
